### PR TITLE
Updates for running subjet b tagging without jet reclustering

### DIFF
--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -354,7 +354,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					jetSource = cms.InputTag( updateCollectionSubjets, 'SubJets' ),
 					labelName = jetALGO+'PF'+PUMethod+'SoftDropPacked',
 					jetCorrections = JEC, 
-		#			btagDiscriminators = bTagDiscriminators,
+		 			btagDiscriminators = bTagDiscriminators,
 					)
 			patSubJets = 'updatedPatJetsAK8PFCHSSoftDropPacked'
 

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -26,7 +26,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		newPFCollection=False, nameNewPFCollection = '',	
 		PUMethod='CHS', 
 		miniAOD=True,
-		runOnMC=True,
+		runOnMC=True, 
+    jetRadius=0.4, ### To be specified for rerunning b tagging on subjets
+    algoLabel='', #### To be specified for rerunning b tagging on subjets 
+    fatJetSource='',  ### To be specified for rerunning b tagging on subjets
 		JETCorrPayload='', JETCorrLevels = [ 'None' ], GetJetMCFlavour=True,
 		Cut = '', 
 		bTagDiscriminators = None, 
@@ -351,9 +354,13 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			print '|---- jetToolBox: JETTOOLBOX IS UPDATING '+updateCollection+' collection for subjets/groomers.'
 			updateJetCollection(
 					proc,
-					jetSource = cms.InputTag( updateCollectionSubjets, 'SubJets' ),
+					jetSource = cms.InputTag( updateCollectionSubjets ),
 					labelName = jetALGO+'PF'+PUMethod+'SoftDropPacked',
 					jetCorrections = JEC, 
+          explicitJTA = True,
+          fatJets = cms.InputTag(fatJetSource),
+          rParam=jetRadius,
+          algo=algoLabel,
 		 			btagDiscriminators = bTagDiscriminators,
 					)
 			patSubJets = 'updatedPatJetsAK8PFCHSSoftDropPacked'


### PR DESCRIPTION
"updateJetCollection" to handle running subjet b tagging:
New configurables: 
- jetRadius, to be set to the size of the fat jet; 
- explicitJTA = True; 
- algoLabel, to be set to 'AK' or 'CA' depending on the jet algorithm.