### PR TITLE
add packing so that one could access softdrop subjets via jetptr->sub…

### DIFF
--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -485,21 +485,20 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			toolsUsed.append( 'selectedPatJets'+jetALGO+'PF'+PUMethod+'SoftDropSubjets' )
 
                         ## Pack fat jets with subjets
-			setattr( proc, 'packedPatJets'+jetALGO+'PF'+PUMethod, 
+			setattr( proc, 'packedPatJets'+jetALGO+'PF'+PUMethod+'SoftDrop', 
 				 cms.EDProducer("JetSubstructurePacker",
 						jetSrc=cms.InputTag('selectedPatJets'+jetALGO+'PF'+PUMethod),
-						distMax = cms.double(0.8),
+						distMax = cms.double( jetSize ),
 						fixDaughters = cms.bool(False),
 						algoTags = cms.VInputTag(
 						cms.InputTag('selectedPatJets'+jetALGO+'PF'+PUMethod+'SoftDropPacked')
 						), 
-						algoLabels =cms.vstring('SoftDrop'
-									)
+						algoLabels =cms.vstring('SoftDrop')
 						)
 				 )
-			jetSeq += getattr(proc, 'packedPatJets'+jetALGO+'PF'+PUMethod)
-			elemToKeep += [ 'keep *_packedPatJets'+jetALGO+'PF'+PUMethod+'_*_*' ]
-			toolsUsed.append( 'packedPatJets'+jetALGO+'PF'+PUMethod )
+			jetSeq += getattr(proc, 'packedPatJets'+jetALGO+'PF'+PUMethod+'SoftDrop')
+			elemToKeep += [ 'keep *_packedPatJets'+jetALGO+'PF'+PUMethod+'SoftDrop_*_*' ]
+			toolsUsed.append( 'packedPatJets'+jetALGO+'PF'+PUMethod+'SoftDrop' )
 
 
 
@@ -594,6 +593,22 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			elemToKeep += [ 'keep *_selectedPatJets'+jetALGO+'PF'+PUMethod+'PrunedPacked_*_*' ]
 			toolsUsed.append( 'selectedPatJets'+jetALGO+'PF'+PUMethod+'PrunedPacked' )
 			toolsUsed.append( 'selectedPatJets'+jetALGO+'PF'+PUMethod+'PrunedSubjets' )
+
+                        ## Pack fat jets with subjets
+			setattr( proc, 'packedPatJets'+jetALGO+'PF'+PUMethod+'Pruned', 
+				 cms.EDProducer("JetSubstructurePacker",
+						jetSrc=cms.InputTag('selectedPatJets'+jetALGO+'PF'+PUMethod),
+						distMax = cms.double( jetSize ),
+						fixDaughters = cms.bool(False),
+						algoTags = cms.VInputTag(
+						cms.InputTag('selectedPatJets'+jetALGO+'PF'+PUMethod+'PrunedPacked')
+						), 
+						algoLabels =cms.vstring('Pruned')
+						)
+				 )
+			jetSeq += getattr(proc, 'packedPatJets'+jetALGO+'PF'+PUMethod+'Pruned')
+			elemToKeep += [ 'keep *_packedPatJets'+jetALGO+'PF'+PUMethod+'Pruned_*_*' ]
+			toolsUsed.append( 'packedPatJets'+jetALGO+'PF'+PUMethod+'Pruned' )
 
 
 	if addTrimming:

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -394,7 +394,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				jetAlgorithm = algorithm, 
 				useExplicitGhosts=True,
 				R0= cms.double(jetSize),
-				#zcut=zCutSD, 
+				zcut=zCutSD, 
 				beta=betaCut,
 				doAreaFastjet = cms.bool(True),
 				writeCompound = cms.bool(True),
@@ -483,6 +483,25 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			elemToKeep += [ 'keep *_selectedPatJets'+jetALGO+'PF'+PUMethod+'SoftDropPacked_*_*' ]
 			toolsUsed.append( 'selectedPatJets'+jetALGO+'PF'+PUMethod+'SoftDropPacked' )
 			toolsUsed.append( 'selectedPatJets'+jetALGO+'PF'+PUMethod+'SoftDropSubjets' )
+
+                        ## Pack fat jets with subjets
+			setattr( proc, 'packedPatJets'+jetALGO+'PF'+PUMethod, 
+				 cms.EDProducer("JetSubstructurePacker",
+						jetSrc=cms.InputTag('selectedPatJets'+jetALGO+'PF'+PUMethod),
+						distMax = cms.double(0.8),
+						fixDaughters = cms.bool(False),
+						algoTags = cms.VInputTag(
+						cms.InputTag('selectedPatJets'+jetALGO+'PF'+PUMethod+'SoftDropPacked')
+						), 
+						algoLabels =cms.vstring('SoftDrop'
+									)
+						)
+				 )
+			jetSeq += getattr(proc, 'packedPatJets'+jetALGO+'PF'+PUMethod)
+			elemToKeep += [ 'keep *_packedPatJets'+jetALGO+'PF'+PUMethod+'_*_*' ]
+			toolsUsed.append( 'packedPatJets'+jetALGO+'PF'+PUMethod )
+
+
 
 	if addPruning or addPrunedSubjets: 
 


### PR DESCRIPTION
Make two changes:

1) add packing of softdrop subjets and fatjets so that we can access subjets via the pointer 
 auto wSubjets = jetptr->subjets("SoftDrop");

2) the parameter zcutSD was not used, now I enable it so that we could change the settings 
 when creating CA15 jet collections.