### PR TITLE
Adding some tools and fixing bugs for next version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check the branch for the correspondent release. This branch is for *CMSSW_8_0_X*
 ```
 cmsrel CMSSW_8_0_20
 cd CMSSW_8_0_20/src/
-git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_80X_V2
+git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_80X_V4
 scram b -j 18
 ```
 To test the toolbox:

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -341,26 +341,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				genParticles = cms.InputTag(genParticlesLabel),
 				outputModules = ['outputFile']
 				) 
-		'''
-				proc,
-				cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix),
-				jetALGO,
-				'PF'+PUMethod,
-				doJTA        = True,
-				doBTagging   = True,
-				jetCorrLabel = JEC if JEC is not None else None, 
-				doType1MET   = True,
-				doL1Cleaning = True,                 
-				doL1Counters = False,
-				genJetCollection = cms.InputTag( jetalgo+'GenJetsNoNu'),
-				doJetID      = True,
-				#jetIdLabel   = jetalgo,
-				btagInfo = bTagInfos,
-				btagdiscriminators = bTagDiscriminators,
-				outputModules = ['outputFile']
-				)
 
-		'''
 		getattr( proc, 'patJets'+jetALGO+'PF'+PUMethod+postFix).addTagInfos = cms.bool(True)
 		if deepBtagFlag: getattr( proc, 'jetTracksAssociatorAtVertex'+jetALGO+'PF'+PUMethod+postFix ).tracks = tvLabel  
 

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -209,13 +209,13 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				srcForPFJets = ( 'puppi' if PUMethod == 'Puppi' else 'newpuppi' )
 
 			from RecoJets.JetProducers.ak4PFJetsPuppi_cfi import ak4PFJetsPuppi
-			setattr( proc, jetalgo+'PFJetsPuppi'+postFix, 
+			setattr( proc, jetalgo+'PFJets'+PUMethod+postFix, 
 					ak4PFJetsPuppi.clone( src = cms.InputTag( srcForPFJets ),
 						doAreaFastjet = True, 
 						rParam = jetSize, 
 						jetPtMin = cms.double( ptCut ),
 						jetAlgorithm = algorithm ) )  
-			jetSeq += getattr(proc, jetalgo+'PFJetsPuppi'+postFix )
+			jetSeq += getattr(proc, jetalgo+'PFJets'+PUMethod+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFPuppi'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFPuppi'

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -203,10 +203,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 						puppi.useExistingWeights = cms.bool(True)
 						print '|---- jetToolBox: Puppi default value. It takes the existing weights from miniAOD.'
 					else:
-						PUMethod = 'Puppi'
+						setattr( proc, 'newpuppi', puppi.clone( eseExistingWeights = cms.bool(False)))
 						print '|---- jetToolBox: It will calculate the weights from scratch. (It is NOT taking the existing weights from miniAOD.)'
-				jetSeq += getattr(proc, 'puppi' )
-				srcForPFJets = 'puppi'
+				jetSeq += getattr(proc, ( 'puppi' if PUMethod == 'Puppi' else 'newpuppi' ) )
+				srcForPFJets = ( 'puppi' if PUMethod == 'Puppi' else 'newpuppi' )
 
 			from RecoJets.JetProducers.ak4PFJetsPuppi_cfi import ak4PFJetsPuppi
 			setattr( proc, jetalgo+'PFJetsPuppi'+postFix, 
@@ -341,7 +341,26 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				genParticles = cms.InputTag(genParticlesLabel),
 				outputModules = ['outputFile']
 				) 
+		'''
+				proc,
+				cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix),
+				jetALGO,
+				'PF'+PUMethod,
+				doJTA        = True,
+				doBTagging   = True,
+				jetCorrLabel = JEC if JEC is not None else None, 
+				doType1MET   = True,
+				doL1Cleaning = True,                 
+				doL1Counters = False,
+				genJetCollection = cms.InputTag( jetalgo+'GenJetsNoNu'),
+				doJetID      = True,
+				#jetIdLabel   = jetalgo,
+				btagInfo = bTagInfos,
+				btagdiscriminators = bTagDiscriminators,
+				outputModules = ['outputFile']
+				)
 
+		'''
 		getattr( proc, 'patJets'+jetALGO+'PF'+PUMethod+postFix).addTagInfos = cms.bool(True)
 		if deepBtagFlag: getattr( proc, 'jetTracksAssociatorAtVertex'+jetALGO+'PF'+PUMethod+postFix ).tracks = tvLabel  
 

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -87,11 +87,11 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	jetALGO = jetAlgo.upper()+size
 	jetalgo = jetAlgo.lower()+size
 	if jetalgo not in recommendedJetAlgos: print '|---- jetToolBox: CMS recommends the following jet algoritms: '+' '.join(recommendedJetAlgos)+'. You are using', jetalgo,'.'
+	
 	### trick for jet pt cut
 	for c in Cut.split('&&'):
-		if 'pt' in c: 
-			ptCut = c.split('>')[1]
-	print ptCut
+		if 'pt' in c: ptCut = c.split('>')[1]
+		else: ptCut = 0
 
 	#################################################################################
 	####### Toolbox start 
@@ -189,11 +189,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			
 
 		####  Creating PATjets
-		tmpPfCandName = pfCand.lower()
 		if 'Puppi' in PUMethod:
-			if ('puppi' in tmpPfCandName): 
+			if newPFCollection: 
 				srcForPFJets = pfCand
-				print '|---- jetToolBox: Not running puppi algorithm because keyword puppi was specified in nameNewPFCollection, but applying puppi corrections.' 
+				print '|---- jetToolBox: Not running puppi algorithm because Puppi is specified in the PUMethod, but applying puppi corrections.' 
 			else: 
 				proc.load('CommonTools.PileupAlgos.Puppi_cff')
 				puppi.candName = cms.InputTag( pfCand ) 
@@ -210,22 +209,22 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				srcForPFJets = 'puppi'
 
 			from RecoJets.JetProducers.ak4PFJetsPuppi_cfi import ak4PFJetsPuppi
-			setattr( proc, jetalgo+'PFJetsPuppi', 
+			setattr( proc, jetalgo+'PFJetsPuppi'+postFix, 
 					ak4PFJetsPuppi.clone( src = cms.InputTag( srcForPFJets ),
 						doAreaFastjet = True, 
 						rParam = jetSize, 
 						jetPtMin = cms.double( ptCut ),
 						jetAlgorithm = algorithm ) )  
-			jetSeq += getattr(proc, jetalgo+'PFJetsPuppi' )
+			jetSeq += getattr(proc, jetalgo+'PFJetsPuppi'+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFPuppi'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFPuppi'
 
 		elif 'SK' in PUMethod:
 
-			if ('sk' in tmpPfCandName): 
+			if newPFCollection: 
 				srcForPFJets = pfCand
-				print '|---- jetToolBox: Not running softkiller algorithm because keyword SK was specified in nameNewPFCollection, but applying SK corrections.' 
+				print '|---- jetToolBox: Not running puppi algorithm because SK is specified in the PUMethod, but applying puppi corrections.' 
 			else:
 				proc.load('CommonTools.PileupAlgos.softKiller_cfi')
 				getattr( proc, 'softKiller' ).PFCandidates = cms.InputTag( pfCand ) 
@@ -233,12 +232,12 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				srcForPFJets = 'softKiller'
 
 			from RecoJets.JetProducers.ak4PFJetsSK_cfi import ak4PFJetsSK
-			setattr( proc, jetalgo+'PFJetsSK', 
+			setattr( proc, jetalgo+'PFJetsSK'+postFix, 
 					ak4PFJetsSK.clone(  src = cms.InputTag( srcForPFJets ),
 						rParam = jetSize, 
 						jetPtMin = cms.double( ptCut ),
 						jetAlgorithm = algorithm ) ) 
-			jetSeq += getattr(proc, jetalgo+'PFJetsSK' )
+			jetSeq += getattr(proc, jetalgo+'PFJetsSK'+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFSK'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFSK'
@@ -246,14 +245,14 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		elif 'CS' in PUMethod: 
 
 			from RecoJets.JetProducers.ak4PFJetsCHSCS_cfi import ak4PFJetsCHSCS
-			setattr( proc, jetalgo+'PFJetsCS', 
+			setattr( proc, jetalgo+'PFJetsCS'+postFix, 
 					ak4PFJetsCHSCS.clone( doAreaFastjet = True, 
 						src = cms.InputTag( pfCand ), 
 						jetPtMin = cms.double( ptCut ),
 						csRParam = cms.double(jetSize),
 						jetAlgorithm = algorithm ) ) 
-			if miniAOD: getattr( proc, jetalgo+'PFJetsCS').src = pfCand
-			jetSeq += getattr(proc, jetalgo+'PFJetsCS' )
+			if miniAOD: getattr( proc, jetalgo+'PFJetsCS'+postFix ).src = pfCand
+			jetSeq += getattr(proc, jetalgo+'PFJetsCS'+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFCS'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFCS'
@@ -261,9 +260,9 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		elif 'CHS' in PUMethod: 
 			
 			if miniAOD:
-				if ('chs' in tmpPfCandName): 
+				if newPFCollection: 
 					srcForPFJets = pfCand
-					print '|---- jetToolBox: Not running CHS algorithm because keyword CHS was specified in nameNewPFCollection, but applying CHS corrections.' 
+					print '|---- jetToolBox: Not running puppi algorithm because CHS is specified in the PUMethod, but applying puppi corrections.' 
 				else: 
 					setattr( proc, 'chs', cms.EDFilter('CandPtrSelector', src = cms.InputTag( pfCand ), cut = cms.string('fromPV')) )
 					jetSeq += getattr(proc, 'chs')
@@ -284,26 +283,26 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					proc.load('CommonTools.ParticleFlow.pfNoPileUpJME_cff')
 					srcForPFJets = 'pfNoPileUpJME'
 				
-			setattr( proc, jetalgo+'PFJetsCHS', 
+			setattr( proc, jetalgo+'PFJetsCHS'+postFix, 
 					ak4PFJetsCHS.clone( src = cms.InputTag( srcForPFJets ), 
 						doAreaFastjet = True, 
 						rParam = jetSize, 
 						jetPtMin = cms.double( ptCut ),
 						jetAlgorithm = algorithm ) ) 
-			jetSeq += getattr(proc, jetalgo+'PFJetsCHS' )
+			jetSeq += getattr(proc, jetalgo+'PFJetsCHS'+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFchs'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFchs'
 
 		else: 
 			PUMethod = ''
-			setattr( proc, jetalgo+'PFJets', 
+			setattr( proc, jetalgo+'PFJets'+postFix, 
 					ak4PFJets.clone( 
 						doAreaFastjet = True, 
 						rParam = jetSize, 
 						jetAlgorithm = algorithm ) ) 
-			if miniAOD: getattr( proc, jetalgo+'PFJets').src = pfCand
-			jetSeq += getattr(proc, jetalgo+'PFJets' )
+			if miniAOD: getattr( proc, jetalgo+'PFJets'+postFix).src = pfCand
+			jetSeq += getattr(proc, jetalgo+'PFJets'+postFix )
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PF'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PF'
 
@@ -318,14 +317,14 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			else: subJEC = ( subJETCorrPayload.replace('CS','chs').replace('SK','chs') , subJETCorrLevels, 'None' )   ### temporary
 
 
-		if ( PUMethod in [ 'CHS', 'CS', 'Puppi' ] ) and miniAOD: setattr( proc, jetalgo+'PFJets'+PUMethod+'Constituents', cms.EDFilter("MiniAODJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod ), cut = cms.string( Cut ) ))
-		else: setattr( proc, jetalgo+'PFJets'+PUMethod+'Constituents', cms.EDFilter("PFJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod ), cut = cms.string( Cut ) ))
-		jetSeq += getattr(proc, jetalgo+'PFJets'+PUMethod+'Constituents' )
+		if ( PUMethod in [ 'CHS', 'CS', 'Puppi' ] ) and miniAOD: setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents', cms.EDFilter("MiniAODJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix ), cut = cms.string( Cut ) ))
+		else: setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents', cms.EDFilter("PFJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix ), cut = cms.string( Cut ) ))
+		jetSeq += getattr(proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents' )
 
 		addJetCollection(
 				proc,
 				labelName = jetALGO+'PF'+PUMethod,
-				jetSource = cms.InputTag( jetalgo+'PFJets'+PUMethod),
+				jetSource = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix),
 				postfix = postFix, 
 				algo = jetalgo,
 				rParam = jetSize,
@@ -344,7 +343,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				) 
 		'''
 				proc,
-				cms.InputTag( jetalgo+'PFJets'+PUMethod),
+				cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix),
 				jetALGO,
 				'PF'+PUMethod,
 				doJTA        = True,
@@ -427,7 +426,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'SoftDrop', 
 			ak8PFJetsCHSSoftDrop.clone( 
-				src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+				src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 				rParam = jetSize, 
 				jetAlgorithm = algorithm, 
 				useExplicitGhosts=True,
@@ -438,7 +437,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				writeCompound = cms.bool(True),
 				jetCollInstanceName=cms.string('SubJets') ) )
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'SoftDropMass', 
-			ak8PFJetsCHSSoftDropMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ), 
+			ak8PFJetsCHSSoftDropMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ), 
 				matched = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix+'SoftDrop'), 
 				distMax = cms.double( jetSize ) ) )
 
@@ -503,7 +502,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					genParticles = cms.InputTag(genParticlesLabel),
 					explicitJTA = True,  # needed for subjet b tagging
 					svClustering = True, # needed for subjet b tagging
-					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod),             # needed for subjet flavor clustering
+					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix),             # needed for subjet flavor clustering
 					groomedFatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix+'SoftDrop'), # needed for subjet flavor clustering
 					outputModules = ['outputFile']
 					) 
@@ -544,7 +543,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Pruned', 
 			ak8PFJetsCHSPruned.clone( 
-				src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+				src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 				rParam = jetSize, 
 				jetAlgorithm = algorithm, 
 				zcut=zCut, 
@@ -554,7 +553,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				jetCollInstanceName=cms.string('SubJets') ) )
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'PrunedMass', 
 			ak8PFJetsCHSPrunedMass.clone( 
-				src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ), 
+				src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ), 
 				matched = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix+'Pruned'), 
 				distMax = cms.double( jetSize ) ) )
 
@@ -613,7 +612,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					genJetCollection = cms.InputTag( jetalgo+'GenJetsNoNuPruned','SubJets'),
 					explicitJTA = True,  # needed for subjet b tagging
 					svClustering = True, # needed for subjet b tagging
-					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod),             # needed for subjet flavor clustering
+					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix),             # needed for subjet flavor clustering
 					groomedFatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix+'Pruned'), # needed for subjet flavor clustering
 					outputModules = ['outputFile']
 					) 
@@ -654,13 +653,13 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Trimmed', 
 				ak8PFJetsCHSTrimmed.clone( 
 					rParam = jetSize, 
-					src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+					src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 					jetAlgorithm = algorithm,
 					rFilt= rFiltTrim,
 					trimPtFracMin= ptFrac) ) 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'TrimmedMass', 
 				ak8PFJetsCHSTrimmedMass.clone( 
-					src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ), 
+					src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ), 
 					matched = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix+'Trimmed'), 
 					distMax = cms.double( jetSize ) ) )
 
@@ -674,14 +673,14 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Filtered', 
 				ak8PFJetsCHSFiltered.clone( 
-					src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+					src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 					rParam = jetSize, 
 					jetAlgorithm = algorithm,
 					rFilt= rfilt,
 					nFilt= nfilt ) ) 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'FilteredMass', 
 				ak8PFJetsCHSFilteredMass.clone( 
-					src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ), 
+					src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ), 
 					matched = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix+'Filtered'), 
 					distMax = cms.double( jetSize ) ) )
 		elemToKeep += [ 'keep *_'+jetalgo+'PFJets'+PUMethod+postFix+'FilteredMass_*_*'] 
@@ -697,7 +696,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			setattr( proc, 'cmsTopTagPFJets'+PUMethod+postFix,  
 					cms.EDProducer("CATopJetProducer",
 						PFJetParameters.clone( 
-							src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+							src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 							doAreaFastjet = cms.bool(True),
 							doRhoFastjet = cms.bool(False),
 							jetPtMin = cms.double(100.0)
@@ -774,7 +773,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					getJetMCFlavour = GetSubjetMCFlavour,
 					explicitJTA = True,  # needed for subjet b tagging
 					svClustering = True, # needed for subjet b tagging
-					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod),             # needed for subjet flavor clustering
+					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix),             # needed for subjet flavor clustering
 					groomedFatJets=cms.InputTag('patJetsCMSTopTag'+PUMethod+postFix), # needed for subjet flavor clustering
 					genParticles = cms.InputTag(genParticlesLabel)
 					)
@@ -800,7 +799,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'MassDropFiltered', 
 					ca15PFJetsCHSMassDropFiltered.clone( 
 						rParam = jetSize,
-						src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+						src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 						) )
 			setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'MassDropFilteredMass', ak8PFJetsCHSPrunedMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix), 
 				matched = cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix+'MassDropFiltered'), distMax = cms.double( jetSize ) ) )
@@ -814,8 +813,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	if addHEPTopTagger: 
 		if ( jetSize >= 1. ) and ( 'CA' in jetALGO ): 
 
-			setattr( proc, 'hepTopTagPFJets'+PUMethod+postFix, hepTopTagPFJetsCHS.clone( src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ) ) )
-			setattr( proc, 'hepTopTagPFJets'+PUMethod+postFix+'Mass'+jetALGO, ak8PFJetsCHSPrunedMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod), 
+			setattr( proc, 'hepTopTagPFJets'+PUMethod+postFix, hepTopTagPFJetsCHS.clone( src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ) ) )
+			setattr( proc, 'hepTopTagPFJets'+PUMethod+postFix+'Mass'+jetALGO, ak8PFJetsCHSPrunedMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix), 
 				matched = cms.InputTag("hepTopTagPFJets"+PUMethod+postFix), distMax = cms.double( jetSize ) ) )
 			elemToKeep += [ 'keep *_hepTopTagPFJets'+PUMethod+postFix+'Mass'+jetALGO+'_*_*' ]
 			getattr( proc, patJets+jetALGO+'PF'+PUMethod+postFix).userData.userFloats.src += [ 'hepTopTagPFJets'+PUMethod+postFix+'Mass'+jetALGO ]
@@ -830,7 +829,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		rangeTau = range(1,maxTau+1)
 		setattr( proc, 'Njettiness'+jetALGO+PUMethod+postFix, 
-				Njettiness.clone( src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),
+				Njettiness.clone( src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),
 					Njets=cms.vuint32(rangeTau),         # compute 1-, 2-, 3-, 4- subjettiness
 					# variables for measure definition : 
 					measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
@@ -894,7 +893,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		from RecoJets.JetProducers.qjetsadder_cfi import QJetsAdder
 		setattr( proc, 'QJetsAdder'+jetALGO, 
-				QJetsAdder.clone( src = cms.InputTag(jetalgo+'PFJets'+PUMethod), 
+				QJetsAdder.clone( src = cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix), 
 					jetRad = cms.double( jetSize ), 
 					jetAlgo = cms.string( jetALGO[0:2] )))
 		elemToKeep += [ 'keep *_QJetsAdder'+jetALGO+'_*_*' ]
@@ -910,7 +909,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			proc.load('RecoJets.JetProducers.QGTagger_cfi') 	## In 74X you need to run some stuff before.
 			setattr( proc, 'QGTagger'+jetALGO+'PF'+PUMethod+postFix, 
 					QGTagger.clone(
-						srcJets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),    # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
+						srcJets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),    # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
 						jetsLabel = cms.string('QGL_AK4PF'+QGjetsLabel)        # Other options (might need to add an ESSource for it): see https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 						)
 					)
@@ -931,7 +930,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 			setattr( proc, jetALGO+'PF'+PUMethod+postFix+'pileupJetIdCalculator',
 					pileupJetIdCalculator.clone(
-						jets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),
+						jets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),
 						rho = cms.InputTag("fixedGridRhoFastjetAll"),
 						vertexes = cms.InputTag(pvLabel),
 						applyJec = cms.bool(True),
@@ -941,7 +940,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			setattr( proc, jetALGO+'PF'+PUMethod+postFix+'pileupJetIdEvaluator',
 					pileupJetIdEvaluator.clone(
 						jetids = cms.InputTag(jetALGO+'PF'+PUMethod+postFix+'pileupJetIdCalculator'),
-						jets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),
+						jets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),
 						rho = cms.InputTag("fixedGridRhoFastjetAll"),
 						vertexes = cms.InputTag(pvLabel)
 						)
@@ -959,7 +958,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		from RecoJets.JetProducers.ECF_cfi import ECF 
 		rangeECF = range(1,maxECF+1)
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'ECF', ECF.clone(
-				src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),
+				src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),
 				Njets = cms.vuint32( rangeECF ),
 				beta = cms.double( ecfBeta ) 
 				))

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -317,8 +317,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			else: subJEC = ( subJETCorrPayload.replace('CS','chs').replace('SK','chs') , subJETCorrLevels, 'None' )   ### temporary
 
 
-		if ( PUMethod in [ 'CHS', 'CS', 'Puppi' ] ) and miniAOD: setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents', cms.EDFilter("MiniAODJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix ), cut = cms.string( Cut ) ))
-		else: setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents', cms.EDFilter("PFJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix ), cut = cms.string( Cut ) ))
+		if ( PUMethod in [ 'CHS', 'CS', 'Puppi' ] ) and miniAOD: setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents', cms.EDProducer("MiniAODJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix ), cut = cms.string( Cut ) ))
+		else: setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents', cms.EDProducer("PFJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix ), cut = cms.string( Cut ) ))
 		jetSeq += getattr(proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents' )
 
 		addJetCollection(

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -203,7 +203,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 						puppi.useExistingWeights = cms.bool(True)
 						print '|---- jetToolBox: Puppi default value. It takes the existing weights from miniAOD.'
 					else:
-						setattr( proc, 'newpuppi', puppi.clone( eseExistingWeights = cms.bool(False)))
+						setattr( proc, 'newpuppi', puppi.clone( useExistingWeights = cms.bool(False)))
 						print '|---- jetToolBox: It will calculate the weights from scratch. (It is NOT taking the existing weights from miniAOD.)'
 				jetSeq += getattr(proc, ( 'puppi' if PUMethod == 'Puppi' else 'newpuppi' ) )
 				srcForPFJets = ( 'puppi' if PUMethod == 'Puppi' else 'newpuppi' )

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -200,6 +200,12 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				if miniAOD:
 					puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
 					puppi.clonePackedCands = cms.bool(True)
+					if PUMethod == 'Puppi':
+						puppi.useExistingWeights = cms.bool(True)
+						print '|---- jetToolBox: Puppi default value. It takes the existing weights from miniAOD.'
+					else:
+						PUMethod = 'Puppi'
+						print '|---- jetToolBox: It will calculate the weights from scratch. (It is NOT taking the existing weights from miniAOD.)'
 				jetSeq += getattr(proc, 'puppi' )
 				srcForPFJets = 'puppi'
 

--- a/test/jettoolbox_cfg.py
+++ b/test/jettoolbox_cfg.py
@@ -37,6 +37,33 @@ from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
 #jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, addNsubSubjets=True ) 
 #jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addSoftDropSubjets=True,  addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, addNsubSubjets=True ) 
 
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
+		runOnMC = True,
+		PUMethod='Puppi',
+		addSoftDropSubjets = True,
+		addSoftDrop = True,
+		addNsub = True,
+		bTagDiscriminators = ['pfCombinedInclusiveSecondaryVertexV2BJetTags'],
+		addCMSTopTagger = False)
+
+process.selectedMuons = cms.EDFilter("CandPtrSelector", src = cms.InputTag("slimmedMuons"), cut = cms.string("pt>50"))
+
+process.pfCHS = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV"))
+process.pfNoMuonCHS =  cms.EDProducer("CandPtrProjector", src = cms.InputTag("pfCHS"), veto = cms.InputTag("selectedMuons"))
+
+jetToolbox( process, 'ak8', 'ak8JetSubsNoLep', 'out',
+            runOnMC = True,
+            PUMethod='Puppi',
+            newPFCollection=True,
+            nameNewPFCollection='pfNoMuonCHS',
+            addSoftDropSubjets = True,
+            addSoftDrop = True,
+            addNsub = True,
+            bTagDiscriminators = ['pfCombinedInclusiveSecondaryVertexV2BJetTags'],
+            addCMSTopTagger = False,
+            postFix="NoLep")
+
+'''
 listBtagDiscriminatorsAK4 = [ 
                 'pfJetProbabilityBJetTags',
                 'pfCombinedInclusiveSecondaryVertexV2BJetTags',
@@ -64,6 +91,7 @@ jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
 		addTrimming=True, 
 		addPruning=True 
 		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
+'''
 #jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', 
 #		PUMethod='CHS',
 #		#updateCollection='slimmedJetsAK8', 
@@ -80,8 +108,8 @@ jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
 #		addPruning=True, 
 #		addSoftDrop=True 
 #		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', JETCorrPayload = 'AK8PFchs', addEnergyCorrFunc=True, addNsubSubjets=True, addTrimming=True, addFiltering=True, addPruning=True, addSoftDrop=True, addSoftDropSubjets=True )  #PUMethod='CHS', addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
 
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', JETCorrPayload = 'AK8PFchs', addEnergyCorrFunc=True, addNsubSubjets=True, addTrimming=True, addFiltering=True, addPruning=True, addSoftDrop=True, addSoftDropSubjets=True )  #PUMethod='CHS', addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
 
 #jetToolbox( process, 'ak4', 'ak4JetSubsUpdate', 'out', updateCollection='slimmedJets', JETCorrPayload = 'AK4PFchs', JETCorrLevels=['L2Relative', 'L3Absolute'], addQGTagger=True, addPUJetID=True, bTagDiscriminators=listBtagDiscriminatorsAK4 ) 
 #jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, addPUJetID=True, postFix='New' ) 
@@ -134,6 +162,7 @@ process.source = cms.Source("PoolSource",
 from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
 process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 
+process.out.fileName = 'newjetToolbox.root'
 #from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
 #process.source.fileNames = filesRelValProdTTbarAODSIM
 

--- a/test/jettoolbox_cfg.py
+++ b/test/jettoolbox_cfg.py
@@ -43,6 +43,11 @@ listBtagDiscriminatorsAK4 = [
                 'pfCombinedMVAV2BJetTags',
                 'pfCombinedCvsLJetTags',
                 'pfCombinedCvsBJetTags',
+		'deepFlavourJetTags:probudsg',
+		'deepFlavourJetTags:probb',
+		'deepFlavourJetTags:probc',
+		'deepFlavourJetTags:probbb',
+		'deepFlavourJetTags:probcc'
                 ]
 jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', 
 		PUMethod='CHS',
@@ -52,33 +57,34 @@ jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
 		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets', 
 		subJETCorrPayload='AK4PFchs', 
 		bTagDiscriminators=listBtagDiscriminatorsAK4, 
+		Cut = 'pt>200',
 		#addNsubSubjets=True, 
 		addPrunedSubjets=True,
 		postFix= 'CollectionTests',
 		addTrimming=True, 
 		addPruning=True 
 		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', 
-		PUMethod='CHS',
-		#updateCollection='slimmedJetsAK8', 
-		JETCorrPayload='AK8PFchs', 
-		addEnergyCorrFunc=True, 
-		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets', 
-		subJETCorrPayload='AK4PFchs', 
-		bTagDiscriminators=listBtagDiscriminatorsAK4, 
-		addNsubSubjets=True, 
-		addPrunedSubjets=True,
-		postFix= 'NEWCOLLECTIONOFJETS',
-		addTrimming=True, 
-		addFiltering=True, 
-		addPruning=True, 
-		addSoftDrop=True 
-		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', 
+#		PUMethod='CHS',
+#		#updateCollection='slimmedJetsAK8', 
+#		JETCorrPayload='AK8PFchs', 
+#		addEnergyCorrFunc=True, 
+#		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets', 
+#		subJETCorrPayload='AK4PFchs', 
+#		bTagDiscriminators=listBtagDiscriminatorsAK4, 
+#		addNsubSubjets=True, 
+#		addPrunedSubjets=True,
+#		postFix= 'NEWCOLLECTIONOFJETS',
+#		addTrimming=True, 
+#		addFiltering=True, 
+#		addPruning=True, 
+#		addSoftDrop=True 
+#		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
 #jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', JETCorrPayload = 'AK8PFchs', addEnergyCorrFunc=True, addNsubSubjets=True, addTrimming=True, addFiltering=True, addPruning=True, addSoftDrop=True, addSoftDropSubjets=True )  #PUMethod='CHS', addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
 
 
-jetToolbox( process, 'ak4', 'ak4JetSubsUpdate', 'out', updateCollection='slimmedJets', JETCorrPayload = 'AK4PFchs', JETCorrLevels=['L2Relative', 'L3Absolute'], addQGTagger=True, addPUJetID=True, bTagDiscriminators=listBtagDiscriminatorsAK4 ) 
-jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, addPUJetID=True, postFix='New' ) 
+#jetToolbox( process, 'ak4', 'ak4JetSubsUpdate', 'out', updateCollection='slimmedJets', JETCorrPayload = 'AK4PFchs', JETCorrLevels=['L2Relative', 'L3Absolute'], addQGTagger=True, addPUJetID=True, bTagDiscriminators=listBtagDiscriminatorsAK4 ) 
+#jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, addPUJetID=True, postFix='New' ) 
 
 
 #jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False ) 
@@ -115,7 +121,7 @@ jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, addPUJetID=Tr
 
 process.endpath = cms.EndPath(process.out)
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 process.source = cms.Source("PoolSource",
 #		fileNames = cms.untracked.vstring(#'file:example.root'
 		fileNames = cms.untracked.vstring(

--- a/test/testJTB_fwlite.py
+++ b/test/testJTB_fwlite.py
@@ -25,12 +25,14 @@ hNumSubjets = ROOT.TH1F("hNumSubJets", ";Number of Subjets", 10, 0, 10 )
 hSubJetsTau1 = ROOT.TH1F("hSubJetsTau1", ";#tau_{1}", 10, 0, 1 )
 
 #EVENT LOOP
-events = Events ('jettoolbox.root')
+#events = Events ('jettoolbox.root')
+#events = Events ('jettoolbox_existingWeights.root')
+events = Events ('jettoolbox_fromScratch.root')
 PUMethod = 'CHS'
 
 handle = Handle("std::vector<pat::Jet>")
 #label = ("selectedPatJetsAK8PF"+PUMethod) 
-label = ('selectedPatJetsAK8PFCHSCollectionTests') 
+label = ('selectedPatJetsAK8PFPuppi') 
 #label = ('packedPatJetsAK8PFCHSSoftDrop') 
 #label = ('packedPatJetsAK8PFCHSPruned') 
 
@@ -48,11 +50,10 @@ for event in events:
 	#event.getByLabel( labelSubjets, handleSubjets )
 	#subjets = handleSubjets.product()
 
-	for i,j in enumerate(jets):
+	#for i,j in enumerate(jets):
 		#print "jetAK8 %3d: pt %5.1f (raw pt %5.1f), eta %+4.2f, mass %5.1f ungroomed, %5.1f softdrop, %5.1f pruned, %5.1f trimmed, %5.1f filtered. " % ( i, j.pt(), j.pt()*j.jecFactor('Uncorrected'), j.eta(), j.mass(), j.userFloat('ak8PFJetsCHSSoftDropMass'), j.userFloat('ak8PFJetsCHSPrunedMass'), j.userFloat('ak8PFJetsCHSTrimmedMass'), j.userFloat('ak8PFJetsCHSFilteredMass'))
-		print j.pt(), j.eta(), j.userFloat('ak8PFJetsCHSCollectionTestsPrunedMass'), j.bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags'), j.bDiscriminator('deepFlavourJetTags:probb')
+		#print j.pt(), j.eta(), j.userFloat('ak8PFJetsCHSCollectionTestsPrunedMass'), j.bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags'), j.bDiscriminator('deepFlavourJetTags:probb')
 			          
-		'''
 	i = 0
 	for jet in jets:
 		#print jet.userFloat("QGTaggerAK4PFCHS:qgLikelihood"), jet.bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags')
@@ -61,21 +62,22 @@ for event in events:
 			#print jet.userFloat("ak8PFJets"+PUMethod+"TrimmedMass"), jet.userFloat("ak8PFJets"+PUMethod+"PrunedMass"), jet.userFloat('NjettinessAK8:tau1'), jet.bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags')
 
 			hJetsPt.Fill( jet.pt() )
-			hJetsCHF.Fill( jet.chargedHadronEnergyFraction() )
-			hJetsCSV.Fill( jet.bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags') )
-			hJetsTrimmedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"TrimmedMass") )
-			hJetsPrunedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"PrunedMass") )
-			hJetsSoftDropMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"SoftDropMass") )
+			#hJetsCHF.Fill( jet.chargedHadronEnergyFraction() )
+			#hJetsCSV.Fill( jet.bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags') )
+			#hJetsTrimmedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"TrimmedMass") )
+			#hJetsPrunedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"PrunedMass") )
+			#hJetsSoftDropMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"SoftDropMass") )
 
 			i += 1
 			if ( i == 1 ):
 				hJet1Pt.Fill( jet.pt() )
-				hJet1CHF.Fill( jet.chargedHadronEnergyFraction() )
-				hJet1TrimmedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"TrimmedMass") )
-				hJet1PrunedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"PrunedMass") )
-				hJet1SoftDropMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"SoftDropMass") )
+				#hJet1CHF.Fill( jet.chargedHadronEnergyFraction() )
+				#hJet1TrimmedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"TrimmedMass") )
+				#hJet1PrunedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"PrunedMass") )
+				#hJet1SoftDropMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"SoftDropMass") )
 
 			
+		'''
 		wSubjets = j.subjets('SoftDrop')
 		#wSubjets = j.subjets('Pruned')
 		for iw,wsub in enumerate( wSubjets ) :

--- a/test/testJTB_fwlite.py
+++ b/test/testJTB_fwlite.py
@@ -29,7 +29,8 @@ events = Events ('jettoolbox.root')
 PUMethod = 'CHS'
 
 handle = Handle("std::vector<pat::Jet>")
-label = ("selectedPatJetsAK8PF"+PUMethod) 
+#label = ("selectedPatJetsAK8PF"+PUMethod) 
+label = ('selectedPatJetsAK8PFCHSCollectionTests') 
 #label = ('packedPatJetsAK8PFCHSSoftDrop') 
 #label = ('packedPatJetsAK8PFCHSPruned') 
 
@@ -48,7 +49,8 @@ for event in events:
 	#subjets = handleSubjets.product()
 
 	for i,j in enumerate(jets):
-		print "jetAK8 %3d: pt %5.1f (raw pt %5.1f), eta %+4.2f, mass %5.1f ungroomed, %5.1f softdrop, %5.1f pruned, %5.1f trimmed, %5.1f filtered. " % ( i, j.pt(), j.pt()*j.jecFactor('Uncorrected'), j.eta(), j.mass(), j.userFloat('ak8PFJetsCHSSoftDropMass'), j.userFloat('ak8PFJetsCHSPrunedMass'), j.userFloat('ak8PFJetsCHSTrimmedMass'), j.userFloat('ak8PFJetsCHSFilteredMass'))
+		#print "jetAK8 %3d: pt %5.1f (raw pt %5.1f), eta %+4.2f, mass %5.1f ungroomed, %5.1f softdrop, %5.1f pruned, %5.1f trimmed, %5.1f filtered. " % ( i, j.pt(), j.pt()*j.jecFactor('Uncorrected'), j.eta(), j.mass(), j.userFloat('ak8PFJetsCHSSoftDropMass'), j.userFloat('ak8PFJetsCHSPrunedMass'), j.userFloat('ak8PFJetsCHSTrimmedMass'), j.userFloat('ak8PFJetsCHSFilteredMass'))
+		print j.pt(), j.eta(), j.userFloat('ak8PFJetsCHSCollectionTestsPrunedMass'), j.bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags'), j.bDiscriminator('deepFlavourJetTags:probb')
 			          
 		'''
 	i = 0
@@ -73,13 +75,13 @@ for event in events:
 				hJet1PrunedMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"PrunedMass") )
 				hJet1SoftDropMass.Fill( jet.userFloat("ak8PFJets"+PUMethod+"SoftDropMass") )
 
-		'''
 			
 		wSubjets = j.subjets('SoftDrop')
 		#wSubjets = j.subjets('Pruned')
 		for iw,wsub in enumerate( wSubjets ) :
 			print "   w subjet %3d: pt %5.1f (raw pt %5.1f), eta %+4.2f, mass %5.1f " % (
 			iw, wsub.pt(), wsub.pt()*wsub.jecFactor('Uncorrected'), wsub.eta(), wsub.mass() )
+		'''
 
 
 #CLEANUP


### PR DESCRIPTION
This PR includes:
 - Now Puppi by default uses exisitingWeights from miniAOD. Includes also another option in case someone wants to run puppi from scratch.
 - pt cut in raw jets if specified to reduce computing time for btagging variables
 - postFix option, to run two jet collections of the same PUMethod with different options
 - adding DeepCSV btag
 - None in btag discriminators now means None. (Before None meant default discriminators)

After some internal tests, I will create a new tag and modify the twiki accordingly.