### PR TITLE
Making transparent the temporary fix for the unscheduled mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check the branch for the correspondent release. This branch is for *CMSSW_9_1_X*
 ```
 cmsrel CMSSW_9_1_1_patch1/
 cd CMSSW_9_1_1_patch1/src/
-git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_91X
+git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_91X_v1
 scram b -j 18
 ```
 To test the toolbox:

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -944,6 +944,22 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				fileName = cms.untracked.string('jettoolbox.root'), 
 				outputCommands = cms.untracked.vstring( elemToKeep ) ) )
 
+	##### (Temporary?) fix to replace unschedule mode
+	if hasattr(proc, 'myTask'): 
+		getattr( proc, 'myTask', cms.Task() ).add(*[getattr(proc,prod) for prod in proc.producers_()])
+		getattr( proc, 'myTask', cms.Task() ).add(*[getattr(proc,filt) for filt in proc.filters_()])
+	else:
+		setattr( proc, 'myTask', cms.Task() )
+		getattr( proc, 'myTask', cms.Task() ).add(*[getattr(proc,prod) for prod in proc.producers_()])
+		getattr( proc, 'myTask', cms.Task() ).add(*[getattr(proc,filt) for filt in proc.filters_()])
+
+	if hasattr(proc, 'endpath'): 
+		getattr( proc, 'endpath').associate( getattr( proc, 'myTask', cms.Task() ) )
+	else: 
+		setattr( proc, 'endpath',
+				cms.EndPath(getattr(proc, outputFile), getattr( proc, 'myTask', cms.Task() )) )
+
+	#### removing mc matching for data
 	if runOnData:
 		from PhysicsTools.PatAlgos.tools.coreTools import removeMCMatching
 		removeMCMatching(proc, names=['Jets'], outputModules=[outputFile])

--- a/test/jettoolbox_cfg.py
+++ b/test/jettoolbox_cfg.py
@@ -115,10 +115,6 @@ jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, addPUJetID=Tr
 
 process.endpath = cms.EndPath(process.out)
 
-process.myTask = cms.Task()
-process.myTask.add(*[getattr(process,prod) for prod in process.producers_()])
-process.myTask.add(*[getattr(process,filt) for filt in process.filters_()])
-process.endpath.associate(process.myTask)
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 process.source = cms.Source("PoolSource",


### PR DESCRIPTION
I'm just introducing the changes from @kpedro88 inside the jetToolbox code, to make it change transparent to the user. 
With this fix, the user shouldn't include anything extra.
This is not the final solution, but it should work for now. I'll create a tag in 91X freezing this working code and update the twiki accordingly.