### PR TITLE
bug-fix: must not set "addTagInfos" for PATJetSelector, as a configur…

### DIFF
--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -464,7 +464,6 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					) 
 
 			setattr( proc, 'selectedPatJets'+jetALGO+'PF'+PUMethod+postFix+'SoftDropSubjets', selectedPatJets.clone( src = patJets+jetALGO+'PF'+PUMethod+postFix+'SoftDropSubjets', cut = CutSubjet ))
-			getattr( proc, 'selectedPatJets'+jetALGO+'PF'+PUMethod+postFix+'SoftDropSubjets').addTagInfos = cms.bool(True)
 
 			# Establish references between PATified fat jets and subjets using the BoostedJetMerger
 			setattr( proc, 'selectedPatJets'+jetALGO+'PF'+PUMethod+postFix+'SoftDropPacked', 


### PR DESCRIPTION
…ation parameter os this name is not defined in PATJetSelector

(causing an exception to be thrown by the edm::ParameterSetDescription mechanism)