### PR TITLE
update ECFs, use postfix consistently

### DIFF
--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -191,12 +191,12 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				srcForPFJets = 'puppi'
 
 			from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJetsPuppi
-			setattr( proc, jetalgo+'PFJetsPuppi', 
+			setattr( proc, jetalgo+'PFJetsPuppi'+postFix, 
 					ak4PFJetsPuppi.clone( src = cms.InputTag( srcForPFJets ),
 						doAreaFastjet = True, 
 						rParam = jetSize, 
 						jetAlgorithm = algorithm ) )  
-			jetSeq += getattr(proc, jetalgo+'PFJetsPuppi' )
+			jetSeq += getattr(proc, jetalgo+'PFJetsPuppi'+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFPuppi'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFPuppi'
@@ -213,11 +213,11 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				srcForPFJets = 'softKiller'
 
 			from RecoJets.JetProducers.ak4PFJetsSK_cfi import ak4PFJetsSK
-			setattr( proc, jetalgo+'PFJetsSK', 
+			setattr( proc, jetalgo+'PFJetsSK'+postFix, 
 					ak4PFJetsSK.clone(  src = cms.InputTag( srcForPFJets ),
 						rParam = jetSize, 
 						jetAlgorithm = algorithm ) ) 
-			jetSeq += getattr(proc, jetalgo+'PFJetsSK' )
+			jetSeq += getattr(proc, jetalgo+'PFJetsSK'+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFSK'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFSK'
@@ -225,13 +225,13 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		elif 'CS' in PUMethod: 
 
 			from RecoJets.JetProducers.ak4PFJetsCHSCS_cfi import ak4PFJetsCHSCS
-			setattr( proc, jetalgo+'PFJetsCS', 
+			setattr( proc, jetalgo+'PFJetsCS'+postFix, 
 					ak4PFJetsCHSCS.clone( doAreaFastjet = True, 
 						src = cms.InputTag( pfCand ), #srcForPFJets ),
 						csRParam = cms.double(jetSize),
 						jetAlgorithm = algorithm ) ) 
-			if miniAOD: getattr( proc, jetalgo+'PFJetsCS').src = pfCand
-			jetSeq += getattr(proc, jetalgo+'PFJetsCS' )
+			if miniAOD: getattr( proc, jetalgo+'PFJetsCS'+postFix).src = pfCand
+			jetSeq += getattr(proc, jetalgo+'PFJetsCS'+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFCS'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFCS'
@@ -262,25 +262,25 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					proc.load('CommonTools.ParticleFlow.pfNoPileUpJME_cff')
 					srcForPFJets = 'pfNoPileUpJME'
 				
-			setattr( proc, jetalgo+'PFJetsCHS', 
+			setattr( proc, jetalgo+'PFJetsCHS'+postFix, 
 					ak4PFJetsCHS.clone( src = cms.InputTag( srcForPFJets ), 
 						doAreaFastjet = True, 
 						rParam = jetSize, 
 						jetAlgorithm = algorithm ) ) 
-			jetSeq += getattr(proc, jetalgo+'PFJetsCHS' )
+			jetSeq += getattr(proc, jetalgo+'PFJetsCHS'+postFix )
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFchs'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFchs'
 
 		else: 
 			PUMethod = ''
-			setattr( proc, jetalgo+'PFJets', 
+			setattr( proc, jetalgo+'PFJets'+postFix, 
 					ak4PFJets.clone( 
 						doAreaFastjet = True, 
 						rParam = jetSize, 
 						jetAlgorithm = algorithm ) ) 
-			if miniAOD: getattr( proc, jetalgo+'PFJets').src = pfCand
-			jetSeq += getattr(proc, jetalgo+'PFJets' )
+			if miniAOD: getattr( proc, jetalgo+'PFJets'+postFix).src = pfCand
+			jetSeq += getattr(proc, jetalgo+'PFJets'+postFix )
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PF'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PF'
 
@@ -295,14 +295,14 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			else: subJEC = ( subJETCorrPayload.replace('CS','chs').replace('SK','chs') , subJETCorrLevels, 'None' )   ### temporary
 
 
-		if ( PUMethod in [ 'CHS', 'CS', 'Puppi' ] ) and miniAOD: setattr( proc, jetalgo+'PFJets'+PUMethod+'Constituents', cms.EDProducer("MiniAODJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod ), cut = cms.string( Cut ) ))
-		else: setattr( proc, jetalgo+'PFJets'+PUMethod+'Constituents', cms.EDProducer("PFJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod ), cut = cms.string( Cut ) ))
-		jetSeq += getattr(proc, jetalgo+'PFJets'+PUMethod+'Constituents' )
+		if ( PUMethod in [ 'CHS', 'CS', 'Puppi' ] ) and miniAOD: setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents', cms.EDProducer("MiniAODJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix ), cut = cms.string( Cut ) ))
+		else: setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents', cms.EDProducer("PFJetConstituentSelector", src = cms.InputTag( jetalgo+'PFJets'+postFix+PUMethod ), cut = cms.string( Cut ) ))
+		jetSeq += getattr(proc, jetalgo+'PFJets'+PUMethod+postFix+'Constituents' )
 
 		addJetCollection(
 				proc,
 				labelName = jetALGO+'PF'+PUMethod,
-				jetSource = cms.InputTag( jetalgo+'PFJets'+PUMethod),
+				jetSource = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix),
 				postfix = postFix, 
 				algo = jetalgo,
 				rParam = jetSize,
@@ -382,7 +382,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'SoftDrop', 
 			ak8PFJetsCHSSoftDrop.clone( 
-				src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+				src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 				rParam = jetSize, 
 				jetAlgorithm = algorithm, 
 				useExplicitGhosts=True,
@@ -393,7 +393,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				writeCompound = cms.bool(True),
 				jetCollInstanceName=cms.string('SubJets') ) )
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'SoftDropMass', 
-			ak8PFJetsCHSSoftDropMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ), 
+			ak8PFJetsCHSSoftDropMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ), 
 				matched = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix+'SoftDrop'), 
 				distMax = cms.double( jetSize ) ) )
 
@@ -458,7 +458,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					genParticles = cms.InputTag(genParticlesLabel),
 					explicitJTA = True,  # needed for subjet b tagging
 					svClustering = True, # needed for subjet b tagging
-					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod),             # needed for subjet flavor clustering
+					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix),             # needed for subjet flavor clustering
 					groomedFatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix+'SoftDrop'), # needed for subjet flavor clustering
 					outputModules = ['outputFile']
 					) 
@@ -497,7 +497,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Pruned', 
 			ak8PFJetsCHSPruned.clone( 
-				src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+				src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 				rParam = jetSize, 
 				jetAlgorithm = algorithm, 
 				zcut=zCut, 
@@ -507,7 +507,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				jetCollInstanceName=cms.string('SubJets') ) )
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'PrunedMass', 
 			ak8PFJetsCHSPrunedMass.clone( 
-				src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ), 
+				src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ), 
 				matched = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix+'Pruned'), 
 				distMax = cms.double( jetSize ) ) )
 
@@ -566,7 +566,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					genJetCollection = cms.InputTag( jetalgo+'GenJetsNoNuPruned','SubJets'),
 					explicitJTA = True,  # needed for subjet b tagging
 					svClustering = True, # needed for subjet b tagging
-					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod),             # needed for subjet flavor clustering
+					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix),             # needed for subjet flavor clustering
 					groomedFatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix+'Pruned'), # needed for subjet flavor clustering
 					outputModules = ['outputFile']
 					) 
@@ -605,13 +605,13 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Trimmed', 
 				ak8PFJetsCHSTrimmed.clone( 
 					rParam = jetSize, 
-					src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+					src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 					jetAlgorithm = algorithm,
 					rFilt= rFiltTrim,
 					trimPtFracMin= ptFrac) ) 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'TrimmedMass', 
 				ak8PFJetsCHSTrimmedMass.clone( 
-					src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ), 
+					src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ), 
 					matched = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix+'Trimmed'), 
 					distMax = cms.double( jetSize ) ) )
 
@@ -625,14 +625,14 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'Filtered', 
 				ak8PFJetsCHSFiltered.clone( 
-					src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+					src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 					rParam = jetSize, 
 					jetAlgorithm = algorithm,
 					rFilt= rfilt,
 					nFilt= nfilt ) ) 
 		setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'FilteredMass', 
 				ak8PFJetsCHSFilteredMass.clone( 
-					src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ), 
+					src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ), 
 					matched = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix+'Filtered'), 
 					distMax = cms.double( jetSize ) ) )
 		elemToKeep += [ 'keep *_'+jetalgo+'PFJets'+PUMethod+postFix+'FilteredMass_*_*'] 
@@ -648,7 +648,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			setattr( proc, 'cmsTopTagPFJets'+PUMethod+postFix,  
 					cms.EDProducer("CATopJetProducer",
 						PFJetParameters.clone( 
-							src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+							src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 							doAreaFastjet = cms.bool(True),
 							doRhoFastjet = cms.bool(False),
 							jetPtMin = cms.double(100.0)
@@ -724,7 +724,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					getJetMCFlavour = GetSubjetMCFlavour,
 					explicitJTA = True,  # needed for subjet b tagging
 					svClustering = True, # needed for subjet b tagging
-					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod),             # needed for subjet flavor clustering
+					fatJets=cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix),             # needed for subjet flavor clustering
 					groomedFatJets=cms.InputTag('patJetsCMSTopTag'+PUMethod+postFix), # needed for subjet flavor clustering
 					genParticles = cms.InputTag(genParticlesLabel)
 					)
@@ -748,7 +748,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'MassDropFiltered', 
 					ca15PFJetsCHSMassDropFiltered.clone( 
 						rParam = jetSize,
-						src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ),
+						src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ),
 						) )
 			setattr( proc, jetalgo+'PFJets'+PUMethod+postFix+'MassDropFilteredMass', ak8PFJetsCHSPrunedMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix), 
 				matched = cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix+'MassDropFiltered'), distMax = cms.double( jetSize ) ) )
@@ -762,8 +762,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	if addHEPTopTagger: 
 		if ( jetSize >= 1. ) and ( 'CA' in jetALGO ): 
 
-			setattr( proc, 'hepTopTagPFJets'+PUMethod+postFix, hepTopTagPFJetsCHS.clone( src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+'Constituents:constituents' if not updateCollection else updateCollection ) ) ) )
-			setattr( proc, 'hepTopTagPFJets'+PUMethod+postFix+'Mass'+jetALGO, ak8PFJetsCHSPrunedMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod), 
+			setattr( proc, 'hepTopTagPFJets'+PUMethod+postFix, hepTopTagPFJetsCHS.clone( src = cms.InputTag( (jetalgo+'PFJets'+PUMethod+postFix+'Constituents:constituents' if not updateCollection else updateCollection ) ) ) )
+			setattr( proc, 'hepTopTagPFJets'+PUMethod+postFix+'Mass'+jetALGO, ak8PFJetsCHSPrunedMass.clone( src = cms.InputTag( jetalgo+'PFJets'+PUMethod+postFix), 
 				matched = cms.InputTag("hepTopTagPFJets"+PUMethod+postFix), distMax = cms.double( jetSize ) ) )
 			elemToKeep += [ 'keep *_hepTopTagPFJets'+PUMethod+postFix+'Mass'+jetALGO+'_*_*' ]
 			getattr( proc, patJets+jetALGO+'PF'+PUMethod+postFix).userData.userFloats.src += [ 'hepTopTagPFJets'+PUMethod+postFix+'Mass'+jetALGO ]
@@ -778,7 +778,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		rangeTau = range(1,maxTau+1)
 		setattr( proc, 'Njettiness'+jetALGO+PUMethod+postFix, 
-				Njettiness.clone( src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),
+				Njettiness.clone( src = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),
 					Njets=cms.vuint32(rangeTau),         # compute 1-, 2-, 3-, 4- subjettiness
 					# variables for measure definition : 
 					measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
@@ -842,7 +842,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		from RecoJets.JetProducers.qjetsadder_cfi import QJetsAdder
 		setattr( proc, 'QJetsAdder'+jetALGO, 
-				QJetsAdder.clone( src = cms.InputTag(jetalgo+'PFJets'+PUMethod), 
+				QJetsAdder.clone( src = cms.InputTag(jetalgo+'PFJets'+PUMethod+postFix), 
 					jetRad = cms.double( jetSize ), 
 					jetAlgo = cms.string( jetALGO[0:2] )))
 		elemToKeep += [ 'keep *_QJetsAdder'+jetALGO+'_*_*' ]
@@ -858,7 +858,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			proc.load('RecoJets.JetProducers.QGTagger_cfi') 	## In 74X you need to run some stuff before.
 			setattr( proc, 'QGTagger'+jetALGO+'PF'+PUMethod+postFix, 
 					QGTagger.clone(
-						srcJets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),    # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
+						srcJets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),    # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
 						jetsLabel = cms.string('QGL_AK4PF'+QGjetsLabel)        # Other options (might need to add an ESSource for it): see https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 						)
 					)
@@ -879,7 +879,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 			setattr( proc, jetALGO+'PF'+PUMethod+postFix+'pileupJetIdCalculator',
 					pileupJetIdCalculator.clone(
-						jets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),
+						jets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),
 						rho = cms.InputTag("fixedGridRhoFastjetAll"),
 						vertexes = cms.InputTag(pvLabel),
 						applyJec = cms.bool(True),
@@ -889,7 +889,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			setattr( proc, jetALGO+'PF'+PUMethod+postFix+'pileupJetIdEvaluator',
 					pileupJetIdEvaluator.clone(
 						jetids = cms.InputTag(jetALGO+'PF'+PUMethod+postFix+'pileupJetIdCalculator'),
-						jets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod if not updateCollection else updateCollection ) ),
+						jets = cms.InputTag( ( jetalgo+'PFJets'+PUMethod+postFix if not updateCollection else updateCollection ) ),
 						rho = cms.InputTag("fixedGridRhoFastjetAll"),
 						vertexes = cms.InputTag(pvLabel)
 						)


### PR DESCRIPTION
1. ECFs now generated in line with https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py. Subjet ECFs are included and can be turned on separately. Limitations:
    * Restricted to Puppi and Softdrop based on advice from @rappoccio. This limitation could be removed if there is demand (but has a bit of complexity in terms of picking the associated grooming algo name).
    * Restricted to the sets of parameters used in miniAOD production. It is non-trivial to allow users to specify sets of four parameters (Njets, type, alpha, beta). Possible to implement if there is demand (maybe using dicts or named tuples), but there probably won't be.
2. The postfix was not applied to the first step (`FastjetJetProducer` instances) or to the miniAOD constituents selector, meaning the toolbox could not be reused with different sets of candidates in the same job. The problem should be remedied now, as far as I could see.

Problems like 2. would be significantly less likely if every construction was assigned to a clearly named variable the first time used or created (instead of repeating e.g. `jetalgo+'PFJets'+PUMethod+postFix` dozens of times).