### PR TITLE
JetToolbox_94X including fix in ECF and remove jettoolbox.root 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # JetToolbox
-Python framework for configuration of jet tools via the jet toolbox. 
+Python framework for configuration of jet tools via the jet toolbox.
 
 ## Instructions
 
 Check the branch for the correspondent release. This branch is for *CMSSW_9_4_X* and higher, then for example:
 ```
-cmsrel CMSSW_9_4_4/
-cd CMSSW_9_4_4/src/
-git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X_v2
+cmsrel CMSSW_9_4_7/
+cd CMSSW_9_4_7/src/
+git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X_v3
 scram b -j 18
 ```
 To test the toolbox:
 ```
 cmsRun JMEAnalysis/JetToolbox/test/jetToolbox_cfg.py
 ```
-In that python file you also can see a basic example on how to use the toolbox.
+This config file run only a test of the capabilities of the jetToolbox, it is physics meaningless. If you want a more meaningful test, please run (takes quite a long time):
+~~~
+cmsRun JMEAnalysis/JetToolbox/test/ClusterWithToolboxAndMakeHistos.py
+~~~
+In this python file you also can see a basic example on how to use the toolbox.
 
 ## More Information
 

--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -1,0 +1,15 @@
+<flags   EDM_PLUGIN="1"/>
+<use   name="FWCore/Framework"/>
+<use   name="FWCore/ParameterSet"/>
+<use   name="root"/>
+<use   name="boost"/>
+<use   name="DataFormats/Candidate"/>
+<use   name="DataFormats/JetReco"/>
+<use   name="DataFormats/PatCandidates"/>
+<use   name="DataFormats/StdDictionaries"/>
+<use   name="DataFormats/WrappedStdDictionaries"/>
+<use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="FWCore/ServiceRegistry"/>
+<use   name="CommonTools/Utils"/>
+<use   name="CommonTools/UtilAlgos"/>
+<use   name="CondFormats/JetMETObjects"/>

--- a/plugins/JetTester.cc
+++ b/plugins/JetTester.cc
@@ -1,0 +1,1734 @@
+// -*- C++ -*-
+//
+// Package:    Analysis/JetTester
+// Class:      JetTester
+// 
+/**\class JetTester JetTester.cc Analysis/JetTester/plugins/JetTester.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  James Dolen
+//         Created:  Thu, 11 Jun 2015 22:52:52 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// DataFormats
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+
+// TFile
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+// root
+#include "TH1.h"
+#include "TH2.h"
+#include "TTree.h"
+#include "TLorentzVector.h"
+
+//
+// class declaration
+//
+
+class JetTester : public edm::EDAnalyzer {
+   public:
+      explicit JetTester(const edm::ParameterSet&);
+      ~JetTester();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob() override;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+
+      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+      // ----------member data ---------------------------
+      edm::EDGetTokenT<pat::JetCollection> ak4jetMiniToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak8jetMiniToken_;
+      edm::EDGetTokenT<pat::JetCollection> puppijetMiniToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak4PFCHSjetToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak8PFjetToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak8PFCHSjetToken_;
+      edm::EDGetTokenT<pat::JetCollection> ca8PFCHSjetToken_;
+      edm::EDGetTokenT<pat::JetCollection> kt8PFCHSjetToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak8PFPUPPIjetToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak12PFCHSjetToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak15PFCHSjetToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak4PFCHSSoftDropSubjetsToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak8PFSoftDropSubjetsToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak8PFCHSSoftDropSubjetsToken_;
+      edm::EDGetTokenT<pat::JetCollection> ca8PFCHSSoftDropSubjetsToken_;
+      edm::EDGetTokenT<pat::JetCollection> kt8PFCHSSoftDropSubjetsToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak8PFPUPPISoftDropSubjetsToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak12PFCHSSoftDropSubjetsToken_;
+      edm::EDGetTokenT<pat::JetCollection> ak15PFCHSSoftDropSubjetsToken_;
+      edm::EDGetTokenT<pat::JetCollection> puppijetToken_;
+      edm::EDGetTokenT<reco::GenJetCollection> ak4genjetToken_;
+      edm::EDGetTokenT<reco::GenJetCollection> ak8genjetToken_;
+      edm::EDGetTokenT<edm::View<reco::GenParticle> > prunedGenToken_;
+      edm::EDGetTokenT<double> rhoToken_;
+      edm::EDGetTokenT<std::vector<reco::Vertex> > vtxToken_;
+
+
+      TH1D * h_ak4chs_pt            ;
+      TH1D * h_ak4chs_mass          ;
+      TH1D * h_ak4chs_rapidity      ;
+      TH1D * h_ak4chs_prunedMass    ;
+      TH1D * h_ak4chs_trimmedMass   ;
+      TH1D * h_ak4chs_filteredMass  ;
+      TH1D * h_ak4chs_softDropMass  ;
+      TH1D * h_ak4chs_tau1          ;
+      TH1D * h_ak4chs_tau2          ;
+      TH1D * h_ak4chs_tau3          ;
+      TH1D * h_ak4chs_tau4          ;
+      TH1D * h_ak4chs_tau32         ;
+      TH1D * h_ak4chs_tau21         ;
+      TH1D * h_ak4chs_ndau          ;
+      TH1D * h_ak4chs_subjetMass    ;  
+      TH1D * h_ak4chs_area          ;  
+      TH1D * h_ak4chs_pt200_mass          ; 
+      TH1D * h_ak4chs_pt200_prunedMass    ; 
+      TH1D * h_ak4chs_pt200_trimmedMass   ; 
+      TH1D * h_ak4chs_pt200_filteredMass  ; 
+      TH1D * h_ak4chs_pt200_softDropMass  ; 
+      TH1D * h_ak4chs_pt200_tau32         ; 
+      TH1D * h_ak4chs_pt200_tau21         ; 
+      TH1D * h_ak4chs_pt200_subjetMass    ; 
+      TH1D * h_ak4chs_pt500_mass          ; 
+      TH1D * h_ak4chs_pt500_prunedMass    ; 
+      TH1D * h_ak4chs_pt500_trimmedMass   ; 
+      TH1D * h_ak4chs_pt500_filteredMass  ; 
+      TH1D * h_ak4chs_pt500_softDropMass  ; 
+      TH1D * h_ak4chs_pt500_tau32         ; 
+      TH1D * h_ak4chs_pt500_tau21         ; 
+      TH1D * h_ak4chs_pt500_subjetMass    ; 
+  
+
+      TH1D * h_ak8pf_pt            ;
+      TH1D * h_ak8pf_mass          ;
+      TH1D * h_ak8pf_rapidity      ;
+      TH1D * h_ak8pf_prunedMass    ;
+      TH1D * h_ak8pf_trimmedMass   ;
+      TH1D * h_ak8pf_filteredMass  ;
+      TH1D * h_ak8pf_softDropMass  ;
+      TH1D * h_ak8pf_tau1          ;
+      TH1D * h_ak8pf_tau2          ;
+      TH1D * h_ak8pf_tau3          ;
+      TH1D * h_ak8pf_tau4          ;
+      TH1D * h_ak8pf_tau32         ;
+      TH1D * h_ak8pf_tau21         ;
+      TH1D * h_ak8pf_ndau          ;
+      TH1D * h_ak8pf_subjetMass    ;  
+      TH1D * h_ak8pf_area          ;  
+      TH1D * h_ak8pf_pt200_mass          ;  
+      TH1D * h_ak8pf_pt200_prunedMass    ; 
+      TH1D * h_ak8pf_pt200_trimmedMass   ; 
+      TH1D * h_ak8pf_pt200_filteredMass  ; 
+      TH1D * h_ak8pf_pt200_softDropMass  ; 
+      TH1D * h_ak8pf_pt200_tau32         ; 
+      TH1D * h_ak8pf_pt200_tau21         ; 
+      TH1D * h_ak8pf_pt200_subjetMass    ; 
+      TH1D * h_ak8pf_pt500_mass          ; 
+      TH1D * h_ak8pf_pt500_prunedMass    ; 
+      TH1D * h_ak8pf_pt500_trimmedMass   ; 
+      TH1D * h_ak8pf_pt500_filteredMass  ; 
+      TH1D * h_ak8pf_pt500_softDropMass  ; 
+      TH1D * h_ak8pf_pt500_tau32         ; 
+      TH1D * h_ak8pf_pt500_tau21         ; 
+      TH1D * h_ak8pf_pt500_subjetMass    ; 
+
+      TH1D * h_ak8chs_pt            ;
+      TH1D * h_ak8chs_mass          ;
+      TH1D * h_ak8chs_rapidity      ;
+      TH1D * h_ak8chs_prunedMass    ;
+      TH1D * h_ak8chs_trimmedMass   ;
+      TH1D * h_ak8chs_filteredMass  ;
+      TH1D * h_ak8chs_softDropMass  ;
+      TH1D * h_ak8chs_tau1          ;
+      TH1D * h_ak8chs_tau2          ;
+      TH1D * h_ak8chs_tau3          ;
+      TH1D * h_ak8chs_tau4          ;
+      TH1D * h_ak8chs_tau32         ;
+      TH1D * h_ak8chs_tau21         ;
+      TH1D * h_ak8chs_ndau          ;
+      TH1D * h_ak8chs_subjetMass    ;  
+      TH1D * h_ak8chs_area          ;  
+      TH1D * h_ak8chs_pt200_mass          ; 
+      TH1D * h_ak8chs_pt200_prunedMass    ; 
+      TH1D * h_ak8chs_pt200_trimmedMass   ; 
+      TH1D * h_ak8chs_pt200_filteredMass  ; 
+      TH1D * h_ak8chs_pt200_softDropMass  ; 
+      TH1D * h_ak8chs_pt200_tau32         ; 
+      TH1D * h_ak8chs_pt200_tau21         ; 
+      TH1D * h_ak8chs_pt200_subjetMass    ; 
+      TH1D * h_ak8chs_pt500_mass          ; 
+      TH1D * h_ak8chs_pt500_prunedMass    ; 
+      TH1D * h_ak8chs_pt500_trimmedMass   ; 
+      TH1D * h_ak8chs_pt500_filteredMass  ; 
+      TH1D * h_ak8chs_pt500_softDropMass  ; 
+      TH1D * h_ak8chs_pt500_tau32         ; 
+      TH1D * h_ak8chs_pt500_tau21         ; 
+      TH1D * h_ak8chs_pt500_subjetMass    ; 
+
+      TH1D * h_ak8puppi_pt            ;
+      TH1D * h_ak8puppi_mass          ;
+      TH1D * h_ak8puppi_rapidity      ;
+      TH1D * h_ak8puppi_prunedMass    ;
+      TH1D * h_ak8puppi_trimmedMass   ;
+      TH1D * h_ak8puppi_filteredMass  ;
+      TH1D * h_ak8puppi_softDropMass  ;
+      TH1D * h_ak8puppi_tau1          ;
+      TH1D * h_ak8puppi_tau2          ;
+      TH1D * h_ak8puppi_tau3          ;
+      TH1D * h_ak8puppi_tau4          ;
+      TH1D * h_ak8puppi_tau32         ;
+      TH1D * h_ak8puppi_tau21         ;
+      TH1D * h_ak8puppi_ndau          ;
+      TH1D * h_ak8puppi_subjetMass    ;  
+      TH1D * h_ak8puppi_area          ;  
+      TH1D * h_ak8puppi_pt200_mass          ; 
+      TH1D * h_ak8puppi_pt200_prunedMass    ; 
+      TH1D * h_ak8puppi_pt200_trimmedMass   ; 
+      TH1D * h_ak8puppi_pt200_filteredMass  ; 
+      TH1D * h_ak8puppi_pt200_softDropMass  ; 
+      TH1D * h_ak8puppi_pt200_tau32         ; 
+      TH1D * h_ak8puppi_pt200_tau21         ; 
+      TH1D * h_ak8puppi_pt200_subjetMass    ; 
+      TH1D * h_ak8puppi_pt500_mass          ; 
+      TH1D * h_ak8puppi_pt500_prunedMass    ; 
+      TH1D * h_ak8puppi_pt500_trimmedMass   ; 
+      TH1D * h_ak8puppi_pt500_filteredMass  ; 
+      TH1D * h_ak8puppi_pt500_softDropMass  ; 
+      TH1D * h_ak8puppi_pt500_tau32         ; 
+      TH1D * h_ak8puppi_pt500_tau21         ; 
+      TH1D * h_ak8puppi_pt500_subjetMass    ; 
+
+
+      TH1D * h_kt8chs_pt            ;
+      TH1D * h_kt8chs_mass          ;
+      TH1D * h_kt8chs_rapidity      ;
+      TH1D * h_kt8chs_prunedMass    ;
+      TH1D * h_kt8chs_trimmedMass   ;
+      TH1D * h_kt8chs_filteredMass  ;
+      TH1D * h_kt8chs_softDropMass  ;
+      TH1D * h_kt8chs_tau1          ;
+      TH1D * h_kt8chs_tau2          ;
+      TH1D * h_kt8chs_tau3          ;
+      TH1D * h_kt8chs_tau4          ;
+      TH1D * h_kt8chs_tau32         ;
+      TH1D * h_kt8chs_tau21         ;
+      TH1D * h_kt8chs_ndau          ;
+      TH1D * h_kt8chs_subjetMass    ;  
+      TH1D * h_kt8chs_area          ;  
+      TH1D * h_kt8chs_pt200_mass          ; 
+      TH1D * h_kt8chs_pt200_prunedMass    ; 
+      TH1D * h_kt8chs_pt200_trimmedMass   ; 
+      TH1D * h_kt8chs_pt200_filteredMass  ; 
+      TH1D * h_kt8chs_pt200_softDropMass  ; 
+      TH1D * h_kt8chs_pt200_tau32         ; 
+      TH1D * h_kt8chs_pt200_tau21         ; 
+      TH1D * h_kt8chs_pt200_subjetMass    ; 
+      TH1D * h_kt8chs_pt500_mass          ; 
+      TH1D * h_kt8chs_pt500_prunedMass    ; 
+      TH1D * h_kt8chs_pt500_trimmedMass   ; 
+      TH1D * h_kt8chs_pt500_filteredMass  ; 
+      TH1D * h_kt8chs_pt500_softDropMass  ; 
+      TH1D * h_kt8chs_pt500_tau32         ; 
+      TH1D * h_kt8chs_pt500_tau21         ; 
+      TH1D * h_kt8chs_pt500_subjetMass    ; 
+
+
+      TH1D * h_ca8chs_pt            ;
+      TH1D * h_ca8chs_mass          ;
+      TH1D * h_ca8chs_rapidity      ;
+      TH1D * h_ca8chs_prunedMass    ;
+      TH1D * h_ca8chs_trimmedMass   ;
+      TH1D * h_ca8chs_filteredMass  ;
+      TH1D * h_ca8chs_softDropMass  ;
+      TH1D * h_ca8chs_tau1          ;
+      TH1D * h_ca8chs_tau2          ;
+      TH1D * h_ca8chs_tau3          ;
+      TH1D * h_ca8chs_tau4          ;
+      TH1D * h_ca8chs_tau32         ;
+      TH1D * h_ca8chs_tau21         ;
+      TH1D * h_ca8chs_ndau          ;
+      TH1D * h_ca8chs_subjetMass    ;  
+      TH1D * h_ca8chs_area          ;  
+      TH1D * h_ca8chs_pt200_mass          ; 
+      TH1D * h_ca8chs_pt200_prunedMass    ; 
+      TH1D * h_ca8chs_pt200_trimmedMass   ; 
+      TH1D * h_ca8chs_pt200_filteredMass  ; 
+      TH1D * h_ca8chs_pt200_softDropMass  ; 
+      TH1D * h_ca8chs_pt200_tau32         ; 
+      TH1D * h_ca8chs_pt200_tau21         ; 
+      TH1D * h_ca8chs_pt200_subjetMass    ; 
+      TH1D * h_ca8chs_pt500_mass          ; 
+      TH1D * h_ca8chs_pt500_prunedMass    ; 
+      TH1D * h_ca8chs_pt500_trimmedMass   ; 
+      TH1D * h_ca8chs_pt500_filteredMass  ; 
+      TH1D * h_ca8chs_pt500_softDropMass  ; 
+      TH1D * h_ca8chs_pt500_tau32         ; 
+      TH1D * h_ca8chs_pt500_tau21         ; 
+      TH1D * h_ca8chs_pt500_subjetMass    ; 
+
+      TH1D * h_ak12chs_pt            ;
+      TH1D * h_ak12chs_mass          ;
+      TH1D * h_ak12chs_rapidity      ;
+      TH1D * h_ak12chs_prunedMass    ;
+      TH1D * h_ak12chs_trimmedMass   ;
+      TH1D * h_ak12chs_filteredMass  ;
+      TH1D * h_ak12chs_softDropMass  ;
+      TH1D * h_ak12chs_tau1          ;
+      TH1D * h_ak12chs_tau2          ;
+      TH1D * h_ak12chs_tau3          ;
+      TH1D * h_ak12chs_tau4          ;
+      TH1D * h_ak12chs_tau32         ;
+      TH1D * h_ak12chs_tau21         ;
+      TH1D * h_ak12chs_ndau          ;
+      TH1D * h_ak12chs_subjetMass    ;  
+      TH1D * h_ak12chs_area          ;  
+      TH1D * h_ak12chs_pt200_mass          ; 
+      TH1D * h_ak12chs_pt200_prunedMass    ; 
+      TH1D * h_ak12chs_pt200_trimmedMass   ; 
+      TH1D * h_ak12chs_pt200_filteredMass  ; 
+      TH1D * h_ak12chs_pt200_softDropMass  ; 
+      TH1D * h_ak12chs_pt200_tau32         ; 
+      TH1D * h_ak12chs_pt200_tau21         ; 
+      TH1D * h_ak12chs_pt200_subjetMass    ; 
+      TH1D * h_ak12chs_pt500_mass          ; 
+      TH1D * h_ak12chs_pt500_prunedMass    ; 
+      TH1D * h_ak12chs_pt500_trimmedMass   ; 
+      TH1D * h_ak12chs_pt500_filteredMass  ; 
+      TH1D * h_ak12chs_pt500_softDropMass  ; 
+      TH1D * h_ak12chs_pt500_tau32         ; 
+      TH1D * h_ak12chs_pt500_tau21         ; 
+      TH1D * h_ak12chs_pt500_subjetMass    ; 
+
+      TH1D * h_ak15chs_pt            ;
+      TH1D * h_ak15chs_mass          ;
+      TH1D * h_ak15chs_rapidity      ;
+      TH1D * h_ak15chs_prunedMass    ;
+      TH1D * h_ak15chs_trimmedMass   ;
+      TH1D * h_ak15chs_filteredMass  ;
+      TH1D * h_ak15chs_softDropMass  ;
+      TH1D * h_ak15chs_tau1          ;
+      TH1D * h_ak15chs_tau2          ;
+      TH1D * h_ak15chs_tau3          ;
+      TH1D * h_ak15chs_tau4          ;
+      TH1D * h_ak15chs_tau32         ;
+      TH1D * h_ak15chs_tau21         ;
+      TH1D * h_ak15chs_ndau          ;
+      TH1D * h_ak15chs_subjetMass    ;  
+      TH1D * h_ak15chs_area          ;  
+      TH1D * h_ak15chs_pt200_mass          ; 
+      TH1D * h_ak15chs_pt200_prunedMass    ; 
+      TH1D * h_ak15chs_pt200_trimmedMass   ; 
+      TH1D * h_ak15chs_pt200_filteredMass  ; 
+      TH1D * h_ak15chs_pt200_softDropMass  ; 
+      TH1D * h_ak15chs_pt200_tau32         ; 
+      TH1D * h_ak15chs_pt200_tau21         ; 
+      TH1D * h_ak15chs_pt200_subjetMass    ; 
+      TH1D * h_ak15chs_pt500_mass          ; 
+      TH1D * h_ak15chs_pt500_prunedMass    ; 
+      TH1D * h_ak15chs_pt500_trimmedMass   ; 
+      TH1D * h_ak15chs_pt500_filteredMass  ; 
+      TH1D * h_ak15chs_pt500_softDropMass  ; 
+      TH1D * h_ak15chs_pt500_tau32         ; 
+      TH1D * h_ak15chs_pt500_tau21         ; 
+      TH1D * h_ak15chs_pt500_subjetMass    ; 
+};
+
+//
+// constructors and destructor
+//
+JetTester::JetTester(const edm::ParameterSet& iConfig):
+    ak4jetMiniToken_(consumes<pat::JetCollection>(edm::InputTag("slimmedJets"))),
+    ak8jetMiniToken_(consumes<pat::JetCollection>(edm::InputTag("slimmedJetsAK8"))),
+    ak4PFCHSjetToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK4PFCHS"))),
+    ak8PFjetToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK8PF"))),
+    ak8PFCHSjetToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK8PFCHS"))),
+    ca8PFCHSjetToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsCA8PFCHS"))),
+    kt8PFCHSjetToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsKT8PFCHS"))),
+    ak8PFPUPPIjetToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK8PFPuppi"))),
+    ak12PFCHSjetToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK12PFCHS"))),
+    ak15PFCHSjetToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK15PFCHS"))),
+    ak4PFCHSSoftDropSubjetsToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK4PFCHSSoftDropPacked","SubJets"))),
+    ak8PFSoftDropSubjetsToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK8PFSoftDropPacked","SubJets"))),
+    ak8PFCHSSoftDropSubjetsToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK8PFCHSSoftDropPacked","SubJets"))),
+    ca8PFCHSSoftDropSubjetsToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsCA8PFCHSSoftDropPacked","SubJets"))),
+    kt8PFCHSSoftDropSubjetsToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsKT8PFCHSSoftDropPacked","SubJets"))),
+    ak8PFPUPPISoftDropSubjetsToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK8PFPuppiSoftDropPacked","SubJets"))),
+    ak12PFCHSSoftDropSubjetsToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK12PFCHSSoftDropPacked","SubJets"))),
+    ak15PFCHSSoftDropSubjetsToken_(consumes<pat::JetCollection>(edm::InputTag("selectedPatJetsAK15PFCHSSoftDropPacked","SubJets"))),
+    puppijetToken_(consumes<pat::JetCollection>(edm::InputTag("slimmedJetsPuppi"))),
+    ak4genjetToken_(consumes<reco::GenJetCollection>(edm::InputTag("slimmedGenJets"))),
+    ak8genjetToken_(consumes<reco::GenJetCollection>(edm::InputTag("slimmedGenJetsAK8"))),
+    prunedGenToken_(consumes<edm::View<reco::GenParticle> >(edm::InputTag("prunedGenParticles"))),
+    rhoToken_(consumes<double>(edm::InputTag("fixedGridRhoFastjetAll"))),
+    vtxToken_(consumes<std::vector<reco::Vertex> >(edm::InputTag("offlineSlimmedPrimaryVertices")))
+{
+
+  edm::Service<TFileService> fs;
+
+  h_ak4chs_pt                  =  fs->make<TH1D>("h_ak4chs_pt"                     ,"",100,0,3000); 
+  h_ak4chs_mass                =  fs->make<TH1D>("h_ak4chs_mass"                   ,"",100,0,500); 
+  h_ak4chs_rapidity            =  fs->make<TH1D>("h_ak4chs_rapidity"               ,"",100,-5, 5); 
+  h_ak4chs_prunedMass          =  fs->make<TH1D>("h_ak4chs_prunedMass"             ,"",100,0,500); 
+  h_ak4chs_trimmedMass         =  fs->make<TH1D>("h_ak4chs_trimmedMass"            ,"",100,0,500); 
+  h_ak4chs_filteredMass        =  fs->make<TH1D>("h_ak4chs_filteredMass"           ,"",100,0,500); 
+  h_ak4chs_softDropMass        =  fs->make<TH1D>("h_ak4chs_softDropMass"           ,"",100,0,500); 
+  h_ak4chs_tau1                =  fs->make<TH1D>("h_ak4chs_tau1"                   ,"",100,0,  1); 
+  h_ak4chs_tau2                =  fs->make<TH1D>("h_ak4chs_tau2"                   ,"",100,0,  1); 
+  h_ak4chs_tau3                =  fs->make<TH1D>("h_ak4chs_tau3"                   ,"",100,0,  1); 
+  h_ak4chs_tau4                =  fs->make<TH1D>("h_ak4chs_tau4"                   ,"",100,0,  1); 
+  h_ak4chs_tau32               =  fs->make<TH1D>("h_ak4chs_tau32"                  ,"",100,0,  1); 
+  h_ak4chs_tau21               =  fs->make<TH1D>("h_ak4chs_tau21"                  ,"",100,0,  1); 
+  h_ak4chs_ndau                =  fs->make<TH1D>("h_ak4chs_ndau"                   ,"",300,0,300); 
+  h_ak4chs_subjetMass          =  fs->make<TH1D>("h_ak4chs_subjetMass"             ,"",100,0,400); 
+  h_ak4chs_area                =  fs->make<TH1D>("h_ak4chs_area"                   ,"",100,0,  8); 
+  h_ak4chs_pt200_mass          =  fs->make<TH1D>("h_ak4chs_pt200_mass"             ,"",100,0,500); 
+  h_ak4chs_pt200_prunedMass    =  fs->make<TH1D>("h_ak4chs_pt200_prunedMass"       ,"",100,0,500); 
+  h_ak4chs_pt200_trimmedMass   =  fs->make<TH1D>("h_ak4chs_pt200_trimmedMass"      ,"",100,0,500); 
+  h_ak4chs_pt200_filteredMass  =  fs->make<TH1D>("h_ak4chs_pt200_filteredMass"     ,"",100,0,500); 
+  h_ak4chs_pt200_softDropMass  =  fs->make<TH1D>("h_ak4chs_pt200_softDropMass"     ,"",100,0,500); 
+  h_ak4chs_pt200_tau32         =  fs->make<TH1D>("h_ak4chs_pt200_tau32"            ,"",100,0,  1); 
+  h_ak4chs_pt200_tau21         =  fs->make<TH1D>("h_ak4chs_pt200_tau21"            ,"",100,0,  1); 
+  h_ak4chs_pt200_subjetMass    =  fs->make<TH1D>("h_ak4chs_pt200_subjetMass"       ,"",100,0,400); 
+  h_ak4chs_pt500_mass          =  fs->make<TH1D>("h_ak4chs_pt500_mass"             ,"",100,0,500); 
+  h_ak4chs_pt500_prunedMass    =  fs->make<TH1D>("h_ak4chs_pt500_prunedMass"       ,"",100,0,500); 
+  h_ak4chs_pt500_trimmedMass   =  fs->make<TH1D>("h_ak4chs_pt500_trimmedMass"      ,"",100,0,500); 
+  h_ak4chs_pt500_filteredMass  =  fs->make<TH1D>("h_ak4chs_pt500_filteredMass"     ,"",100,0,500); 
+  h_ak4chs_pt500_softDropMass  =  fs->make<TH1D>("h_ak4chs_pt500_softDropMass"     ,"",100,0,500); 
+  h_ak4chs_pt500_tau32         =  fs->make<TH1D>("h_ak4chs_pt500_tau32"            ,"",100,0,  1); 
+  h_ak4chs_pt500_tau21         =  fs->make<TH1D>("h_ak4chs_pt500_tau21"            ,"",100,0,  1); 
+  h_ak4chs_pt500_subjetMass    =  fs->make<TH1D>("h_ak4chs_pt500_subjetMass"       ,"",100,0,400); 
+
+
+  h_ak8pf_pt                  =  fs->make<TH1D>("h_ak8pf_pt"                     ,"",100,0,3000); 
+  h_ak8pf_mass                =  fs->make<TH1D>("h_ak8pf_mass"                   ,"",100,0,500); 
+  h_ak8pf_rapidity            =  fs->make<TH1D>("h_ak8pf_rapidity"               ,"",100,-5, 5); 
+  h_ak8pf_prunedMass          =  fs->make<TH1D>("h_ak8pf_prunedMass"             ,"",100,0,500); 
+  h_ak8pf_trimmedMass         =  fs->make<TH1D>("h_ak8pf_trimmedMass"            ,"",100,0,500); 
+  h_ak8pf_filteredMass        =  fs->make<TH1D>("h_ak8pf_filteredMass"           ,"",100,0,500); 
+  h_ak8pf_softDropMass        =  fs->make<TH1D>("h_ak8pf_softDropMass"           ,"",100,0,500); 
+  h_ak8pf_tau1                =  fs->make<TH1D>("h_ak8pf_tau1"                   ,"",100,0,  1); 
+  h_ak8pf_tau2                =  fs->make<TH1D>("h_ak8pf_tau2"                   ,"",100,0,  1); 
+  h_ak8pf_tau3                =  fs->make<TH1D>("h_ak8pf_tau3"                   ,"",100,0,  1); 
+  h_ak8pf_tau4                =  fs->make<TH1D>("h_ak8pf_tau4"                   ,"",100,0,  1); 
+  h_ak8pf_tau32               =  fs->make<TH1D>("h_ak8pf_tau32"                  ,"",100,0,  1); 
+  h_ak8pf_tau21               =  fs->make<TH1D>("h_ak8pf_tau21"                  ,"",100,0,  1); 
+  h_ak8pf_ndau                =  fs->make<TH1D>("h_ak8pf_ndau"                   ,"",300,0,300); 
+  h_ak8pf_subjetMass          =  fs->make<TH1D>("h_ak8pf_subjetMass"             ,"",100,0,400); 
+  h_ak8pf_area                =  fs->make<TH1D>("h_ak8pf_area"                   ,"",100,0,  8); 
+  h_ak8pf_pt200_mass          =  fs->make<TH1D>("h_ak8pf_pt200_mass"             ,"",100,0,500); 
+  h_ak8pf_pt200_prunedMass    =  fs->make<TH1D>("h_ak8pf_pt200_prunedMass"       ,"",100,0,500); 
+  h_ak8pf_pt200_trimmedMass   =  fs->make<TH1D>("h_ak8pf_pt200_trimmedMass"      ,"",100,0,500); 
+  h_ak8pf_pt200_filteredMass  =  fs->make<TH1D>("h_ak8pf_pt200_filteredMass"     ,"",100,0,500); 
+  h_ak8pf_pt200_softDropMass  =  fs->make<TH1D>("h_ak8pf_pt200_softDropMass"     ,"",100,0,500); 
+  h_ak8pf_pt200_tau32         =  fs->make<TH1D>("h_ak8pf_pt200_tau32"            ,"",100,0,  1); 
+  h_ak8pf_pt200_tau21         =  fs->make<TH1D>("h_ak8pf_pt200_tau21"            ,"",100,0,  1); 
+  h_ak8pf_pt200_subjetMass    =  fs->make<TH1D>("h_ak8pf_pt200_subjetMass"       ,"",100,0,400); 
+  h_ak8pf_pt500_mass          =  fs->make<TH1D>("h_ak8pf_pt500_mass"             ,"",100,0,500); 
+  h_ak8pf_pt500_prunedMass    =  fs->make<TH1D>("h_ak8pf_pt500_prunedMass"       ,"",100,0,500); 
+  h_ak8pf_pt500_trimmedMass   =  fs->make<TH1D>("h_ak8pf_pt500_trimmedMass"      ,"",100,0,500); 
+  h_ak8pf_pt500_filteredMass  =  fs->make<TH1D>("h_ak8pf_pt500_filteredMass"     ,"",100,0,500); 
+  h_ak8pf_pt500_softDropMass  =  fs->make<TH1D>("h_ak8pf_pt500_softDropMass"     ,"",100,0,500); 
+  h_ak8pf_pt500_tau32         =  fs->make<TH1D>("h_ak8pf_pt500_tau32"            ,"",100,0,  1); 
+  h_ak8pf_pt500_tau21         =  fs->make<TH1D>("h_ak8pf_pt500_tau21"            ,"",100,0,  1); 
+  h_ak8pf_pt500_subjetMass    =  fs->make<TH1D>("h_ak8pf_pt500_subjetMass"       ,"",100,0,400); 
+
+
+  h_ak8chs_pt                  =  fs->make<TH1D>("h_ak8chs_pt"                     ,"",100,0,3000); 
+  h_ak8chs_mass                =  fs->make<TH1D>("h_ak8chs_mass"                   ,"",100,0,500); 
+  h_ak8chs_rapidity            =  fs->make<TH1D>("h_ak8chs_rapidity"               ,"",100,-5, 5); 
+  h_ak8chs_prunedMass          =  fs->make<TH1D>("h_ak8chs_prunedMass"             ,"",100,0,500); 
+  h_ak8chs_trimmedMass         =  fs->make<TH1D>("h_ak8chs_trimmedMass"            ,"",100,0,500); 
+  h_ak8chs_filteredMass        =  fs->make<TH1D>("h_ak8chs_filteredMass"           ,"",100,0,500); 
+  h_ak8chs_softDropMass        =  fs->make<TH1D>("h_ak8chs_softDropMass"           ,"",100,0,500); 
+  h_ak8chs_tau1                =  fs->make<TH1D>("h_ak8chs_tau1"                   ,"",100,0,  1); 
+  h_ak8chs_tau2                =  fs->make<TH1D>("h_ak8chs_tau2"                   ,"",100,0,  1); 
+  h_ak8chs_tau3                =  fs->make<TH1D>("h_ak8chs_tau3"                   ,"",100,0,  1); 
+  h_ak8chs_tau4                =  fs->make<TH1D>("h_ak8chs_tau4"                   ,"",100,0,  1); 
+  h_ak8chs_tau32               =  fs->make<TH1D>("h_ak8chs_tau32"                  ,"",100,0,  1); 
+  h_ak8chs_tau21               =  fs->make<TH1D>("h_ak8chs_tau21"                  ,"",100,0,  1); 
+  h_ak8chs_ndau                =  fs->make<TH1D>("h_ak8chs_ndau"                   ,"",300,0,300); 
+  h_ak8chs_subjetMass          =  fs->make<TH1D>("h_ak8chs_subjetMass"             ,"",100,0,400); 
+  h_ak8chs_area                =  fs->make<TH1D>("h_ak8chs_area"                   ,"",100,0,  8); 
+  h_ak8chs_pt200_mass          =  fs->make<TH1D>("h_ak8chs_pt200_mass"             ,"",100,0,500); 
+  h_ak8chs_pt200_prunedMass    =  fs->make<TH1D>("h_ak8chs_pt200_prunedMass"       ,"",100,0,500); 
+  h_ak8chs_pt200_trimmedMass   =  fs->make<TH1D>("h_ak8chs_pt200_trimmedMass"      ,"",100,0,500); 
+  h_ak8chs_pt200_filteredMass  =  fs->make<TH1D>("h_ak8chs_pt200_filteredMass"     ,"",100,0,500); 
+  h_ak8chs_pt200_softDropMass  =  fs->make<TH1D>("h_ak8chs_pt200_softDropMass"     ,"",100,0,500); 
+  h_ak8chs_pt200_tau32         =  fs->make<TH1D>("h_ak8chs_pt200_tau32"            ,"",100,0,  1); 
+  h_ak8chs_pt200_tau21         =  fs->make<TH1D>("h_ak8chs_pt200_tau21"            ,"",100,0,  1); 
+  h_ak8chs_pt200_subjetMass    =  fs->make<TH1D>("h_ak8chs_pt200_subjetMass"       ,"",100,0,400); 
+  h_ak8chs_pt500_mass          =  fs->make<TH1D>("h_ak8chs_pt500_mass"             ,"",100,0,500); 
+  h_ak8chs_pt500_prunedMass    =  fs->make<TH1D>("h_ak8chs_pt500_prunedMass"       ,"",100,0,500); 
+  h_ak8chs_pt500_trimmedMass   =  fs->make<TH1D>("h_ak8chs_pt500_trimmedMass"      ,"",100,0,500); 
+  h_ak8chs_pt500_filteredMass  =  fs->make<TH1D>("h_ak8chs_pt500_filteredMass"     ,"",100,0,500); 
+  h_ak8chs_pt500_softDropMass  =  fs->make<TH1D>("h_ak8chs_pt500_softDropMass"     ,"",100,0,500); 
+  h_ak8chs_pt500_tau32         =  fs->make<TH1D>("h_ak8chs_pt500_tau32"            ,"",100,0,  1); 
+  h_ak8chs_pt500_tau21         =  fs->make<TH1D>("h_ak8chs_pt500_tau21"            ,"",100,0,  1); 
+  h_ak8chs_pt500_subjetMass    =  fs->make<TH1D>("h_ak8chs_pt500_subjetMass"       ,"",100,0,400); 
+
+
+  h_ak8puppi_pt                  =  fs->make<TH1D>("h_ak8puppi_pt"                     ,"",100,0,3000); 
+  h_ak8puppi_mass                =  fs->make<TH1D>("h_ak8puppi_mass"                   ,"",100,0,500); 
+  h_ak8puppi_rapidity            =  fs->make<TH1D>("h_ak8puppi_rapidity"               ,"",100,-5, 5); 
+  h_ak8puppi_prunedMass          =  fs->make<TH1D>("h_ak8puppi_prunedMass"             ,"",100,0,500); 
+  h_ak8puppi_trimmedMass         =  fs->make<TH1D>("h_ak8puppi_trimmedMass"            ,"",100,0,500); 
+  h_ak8puppi_filteredMass        =  fs->make<TH1D>("h_ak8puppi_filteredMass"           ,"",100,0,500); 
+  h_ak8puppi_softDropMass        =  fs->make<TH1D>("h_ak8puppi_softDropMass"           ,"",100,0,500); 
+  h_ak8puppi_tau1                =  fs->make<TH1D>("h_ak8puppi_tau1"                   ,"",100,0,  1); 
+  h_ak8puppi_tau2                =  fs->make<TH1D>("h_ak8puppi_tau2"                   ,"",100,0,  1); 
+  h_ak8puppi_tau3                =  fs->make<TH1D>("h_ak8puppi_tau3"                   ,"",100,0,  1); 
+  h_ak8puppi_tau4                =  fs->make<TH1D>("h_ak8puppi_tau4"                   ,"",100,0,  1); 
+  h_ak8puppi_tau32               =  fs->make<TH1D>("h_ak8puppi_tau32"                  ,"",100,0,  1); 
+  h_ak8puppi_tau21               =  fs->make<TH1D>("h_ak8puppi_tau21"                  ,"",100,0,  1); 
+  h_ak8puppi_ndau                =  fs->make<TH1D>("h_ak8puppi_ndau"                   ,"",300,0,300); 
+  h_ak8puppi_subjetMass          =  fs->make<TH1D>("h_ak8puppi_subjetMass"             ,"",100,0,400); 
+  h_ak8puppi_area                =  fs->make<TH1D>("h_ak8puppi_area"                   ,"",100,0,  8); 
+  h_ak8puppi_pt200_mass          =  fs->make<TH1D>("h_ak8puppi_pt200_mass"             ,"",100,0,500); 
+  h_ak8puppi_pt200_prunedMass    =  fs->make<TH1D>("h_ak8puppi_pt200_prunedMass"       ,"",100,0,500); 
+  h_ak8puppi_pt200_trimmedMass   =  fs->make<TH1D>("h_ak8puppi_pt200_trimmedMass"      ,"",100,0,500); 
+  h_ak8puppi_pt200_filteredMass  =  fs->make<TH1D>("h_ak8puppi_pt200_filteredMass"     ,"",100,0,500); 
+  h_ak8puppi_pt200_softDropMass  =  fs->make<TH1D>("h_ak8puppi_pt200_softDropMass"     ,"",100,0,500); 
+  h_ak8puppi_pt200_tau32         =  fs->make<TH1D>("h_ak8puppi_pt200_tau32"            ,"",100,0,  1); 
+  h_ak8puppi_pt200_tau21         =  fs->make<TH1D>("h_ak8puppi_pt200_tau21"            ,"",100,0,  1); 
+  h_ak8puppi_pt200_subjetMass    =  fs->make<TH1D>("h_ak8puppi_pt200_subjetMass"       ,"",100,0,400); 
+  h_ak8puppi_pt500_mass          =  fs->make<TH1D>("h_ak8puppi_pt500_mass"             ,"",100,0,500); 
+  h_ak8puppi_pt500_prunedMass    =  fs->make<TH1D>("h_ak8puppi_pt500_prunedMass"       ,"",100,0,500); 
+  h_ak8puppi_pt500_trimmedMass   =  fs->make<TH1D>("h_ak8puppi_pt500_trimmedMass"      ,"",100,0,500); 
+  h_ak8puppi_pt500_filteredMass  =  fs->make<TH1D>("h_ak8puppi_pt500_filteredMass"     ,"",100,0,500); 
+  h_ak8puppi_pt500_softDropMass  =  fs->make<TH1D>("h_ak8puppi_pt500_softDropMass"     ,"",100,0,500); 
+  h_ak8puppi_pt500_tau32         =  fs->make<TH1D>("h_ak8puppi_pt500_tau32"            ,"",100,0,  1); 
+  h_ak8puppi_pt500_tau21         =  fs->make<TH1D>("h_ak8puppi_pt500_tau21"            ,"",100,0,  1); 
+  h_ak8puppi_pt500_subjetMass    =  fs->make<TH1D>("h_ak8puppi_pt500_subjetMass"       ,"",100,0,400); 
+
+
+  h_kt8chs_pt                  =  fs->make<TH1D>("h_kt8chs_pt"                     ,"",100,0,3000); 
+  h_kt8chs_mass                =  fs->make<TH1D>("h_kt8chs_mass"                   ,"",100,0,500); 
+  h_kt8chs_rapidity            =  fs->make<TH1D>("h_kt8chs_rapidity"               ,"",100,-5, 5); 
+  h_kt8chs_prunedMass          =  fs->make<TH1D>("h_kt8chs_prunedMass"             ,"",100,0,500); 
+  h_kt8chs_trimmedMass         =  fs->make<TH1D>("h_kt8chs_trimmedMass"            ,"",100,0,500); 
+  h_kt8chs_filteredMass        =  fs->make<TH1D>("h_kt8chs_filteredMass"           ,"",100,0,500); 
+  h_kt8chs_softDropMass        =  fs->make<TH1D>("h_kt8chs_softDropMass"           ,"",100,0,500); 
+  h_kt8chs_tau1                =  fs->make<TH1D>("h_kt8chs_tau1"                   ,"",100,0,  1); 
+  h_kt8chs_tau2                =  fs->make<TH1D>("h_kt8chs_tau2"                   ,"",100,0,  1); 
+  h_kt8chs_tau3                =  fs->make<TH1D>("h_kt8chs_tau3"                   ,"",100,0,  1); 
+  h_kt8chs_tau4                =  fs->make<TH1D>("h_kt8chs_tau4"                   ,"",100,0,  1); 
+  h_kt8chs_tau32               =  fs->make<TH1D>("h_kt8chs_tau32"                  ,"",100,0,  1); 
+  h_kt8chs_tau21               =  fs->make<TH1D>("h_kt8chs_tau21"                  ,"",100,0,  1); 
+  h_kt8chs_ndau                =  fs->make<TH1D>("h_kt8chs_ndau"                   ,"",300,0,300); 
+  h_kt8chs_subjetMass          =  fs->make<TH1D>("h_kt8chs_subjetMass"             ,"",100,0,400); 
+  h_kt8chs_area                =  fs->make<TH1D>("h_kt8chs_area"                   ,"",100,0,  8); 
+  h_kt8chs_pt200_mass          =  fs->make<TH1D>("h_kt8chs_pt200_mass"             ,"",100,0,500); 
+  h_kt8chs_pt200_prunedMass    =  fs->make<TH1D>("h_kt8chs_pt200_prunedMass"       ,"",100,0,500); 
+  h_kt8chs_pt200_trimmedMass   =  fs->make<TH1D>("h_kt8chs_pt200_trimmedMass"      ,"",100,0,500); 
+  h_kt8chs_pt200_filteredMass  =  fs->make<TH1D>("h_kt8chs_pt200_filteredMass"     ,"",100,0,500); 
+  h_kt8chs_pt200_softDropMass  =  fs->make<TH1D>("h_kt8chs_pt200_softDropMass"     ,"",100,0,500); 
+  h_kt8chs_pt200_tau32         =  fs->make<TH1D>("h_kt8chs_pt200_tau32"            ,"",100,0,  1); 
+  h_kt8chs_pt200_tau21         =  fs->make<TH1D>("h_kt8chs_pt200_tau21"            ,"",100,0,  1); 
+  h_kt8chs_pt200_subjetMass    =  fs->make<TH1D>("h_kt8chs_pt200_subjetMass"       ,"",100,0,400); 
+  h_kt8chs_pt500_mass          =  fs->make<TH1D>("h_kt8chs_pt500_mass"             ,"",100,0,500); 
+  h_kt8chs_pt500_prunedMass    =  fs->make<TH1D>("h_kt8chs_pt500_prunedMass"       ,"",100,0,500); 
+  h_kt8chs_pt500_trimmedMass   =  fs->make<TH1D>("h_kt8chs_pt500_trimmedMass"      ,"",100,0,500); 
+  h_kt8chs_pt500_filteredMass  =  fs->make<TH1D>("h_kt8chs_pt500_filteredMass"     ,"",100,0,500); 
+  h_kt8chs_pt500_softDropMass  =  fs->make<TH1D>("h_kt8chs_pt500_softDropMass"     ,"",100,0,500); 
+  h_kt8chs_pt500_tau32         =  fs->make<TH1D>("h_kt8chs_pt500_tau32"            ,"",100,0,  1); 
+  h_kt8chs_pt500_tau21         =  fs->make<TH1D>("h_kt8chs_pt500_tau21"            ,"",100,0,  1); 
+  h_kt8chs_pt500_subjetMass    =  fs->make<TH1D>("h_kt8chs_pt500_subjetMass"       ,"",100,0,400); 
+
+
+  h_ca8chs_pt                  =  fs->make<TH1D>("h_ca8chs_pt"                     ,"",100,0,3000); 
+  h_ca8chs_mass                =  fs->make<TH1D>("h_ca8chs_mass"                   ,"",100,0,500); 
+  h_ca8chs_rapidity            =  fs->make<TH1D>("h_ca8chs_rapidity"               ,"",100,-5, 5); 
+  h_ca8chs_prunedMass          =  fs->make<TH1D>("h_ca8chs_prunedMass"             ,"",100,0,500); 
+  h_ca8chs_trimmedMass         =  fs->make<TH1D>("h_ca8chs_trimmedMass"            ,"",100,0,500); 
+  h_ca8chs_filteredMass        =  fs->make<TH1D>("h_ca8chs_filteredMass"           ,"",100,0,500); 
+  h_ca8chs_softDropMass        =  fs->make<TH1D>("h_ca8chs_softDropMass"           ,"",100,0,500); 
+  h_ca8chs_tau1                =  fs->make<TH1D>("h_ca8chs_tau1"                   ,"",100,0,  1); 
+  h_ca8chs_tau2                =  fs->make<TH1D>("h_ca8chs_tau2"                   ,"",100,0,  1); 
+  h_ca8chs_tau3                =  fs->make<TH1D>("h_ca8chs_tau3"                   ,"",100,0,  1); 
+  h_ca8chs_tau4                =  fs->make<TH1D>("h_ca8chs_tau4"                   ,"",100,0,  1); 
+  h_ca8chs_tau32               =  fs->make<TH1D>("h_ca8chs_tau32"                  ,"",100,0,  1); 
+  h_ca8chs_tau21               =  fs->make<TH1D>("h_ca8chs_tau21"                  ,"",100,0,  1); 
+  h_ca8chs_ndau                =  fs->make<TH1D>("h_ca8chs_ndau"                   ,"",300,0,300); 
+  h_ca8chs_subjetMass          =  fs->make<TH1D>("h_ca8chs_subjetMass"             ,"",100,0,400); 
+  h_ca8chs_area                =  fs->make<TH1D>("h_ca8chs_area"                   ,"",100,0,  8); 
+  h_ca8chs_pt200_mass          =  fs->make<TH1D>("h_ca8chs_pt200_mass"             ,"",100,0,500); 
+  h_ca8chs_pt200_prunedMass    =  fs->make<TH1D>("h_ca8chs_pt200_prunedMass"       ,"",100,0,500); 
+  h_ca8chs_pt200_trimmedMass   =  fs->make<TH1D>("h_ca8chs_pt200_trimmedMass"      ,"",100,0,500); 
+  h_ca8chs_pt200_filteredMass  =  fs->make<TH1D>("h_ca8chs_pt200_filteredMass"     ,"",100,0,500); 
+  h_ca8chs_pt200_softDropMass  =  fs->make<TH1D>("h_ca8chs_pt200_softDropMass"     ,"",100,0,500); 
+  h_ca8chs_pt200_tau32         =  fs->make<TH1D>("h_ca8chs_pt200_tau32"            ,"",100,0,  1); 
+  h_ca8chs_pt200_tau21         =  fs->make<TH1D>("h_ca8chs_pt200_tau21"            ,"",100,0,  1); 
+  h_ca8chs_pt200_subjetMass    =  fs->make<TH1D>("h_ca8chs_pt200_subjetMass"       ,"",100,0,400); 
+  h_ca8chs_pt500_mass          =  fs->make<TH1D>("h_ca8chs_pt500_mass"             ,"",100,0,500); 
+  h_ca8chs_pt500_prunedMass    =  fs->make<TH1D>("h_ca8chs_pt500_prunedMass"       ,"",100,0,500); 
+  h_ca8chs_pt500_trimmedMass   =  fs->make<TH1D>("h_ca8chs_pt500_trimmedMass"      ,"",100,0,500); 
+  h_ca8chs_pt500_filteredMass  =  fs->make<TH1D>("h_ca8chs_pt500_filteredMass"     ,"",100,0,500); 
+  h_ca8chs_pt500_softDropMass  =  fs->make<TH1D>("h_ca8chs_pt500_softDropMass"     ,"",100,0,500); 
+  h_ca8chs_pt500_tau32         =  fs->make<TH1D>("h_ca8chs_pt500_tau32"            ,"",100,0,  1); 
+  h_ca8chs_pt500_tau21         =  fs->make<TH1D>("h_ca8chs_pt500_tau21"            ,"",100,0,  1); 
+  h_ca8chs_pt500_subjetMass    =  fs->make<TH1D>("h_ca8chs_pt500_subjetMass"       ,"",100,0,400); 
+
+
+
+  h_ak12chs_pt                  =  fs->make<TH1D>("h_ak12chs_pt"                     ,"",100,0,3000); 
+  h_ak12chs_mass                =  fs->make<TH1D>("h_ak12chs_mass"                   ,"",100,0,500); 
+  h_ak12chs_rapidity            =  fs->make<TH1D>("h_ak12chs_rapidity"               ,"",100,-5, 5); 
+  h_ak12chs_prunedMass          =  fs->make<TH1D>("h_ak12chs_prunedMass"             ,"",100,0,500); 
+  h_ak12chs_trimmedMass         =  fs->make<TH1D>("h_ak12chs_trimmedMass"            ,"",100,0,500); 
+  h_ak12chs_filteredMass        =  fs->make<TH1D>("h_ak12chs_filteredMass"           ,"",100,0,500); 
+  h_ak12chs_softDropMass        =  fs->make<TH1D>("h_ak12chs_softDropMass"           ,"",100,0,500); 
+  h_ak12chs_tau1                =  fs->make<TH1D>("h_ak12chs_tau1"                   ,"",100,0,  1); 
+  h_ak12chs_tau2                =  fs->make<TH1D>("h_ak12chs_tau2"                   ,"",100,0,  1); 
+  h_ak12chs_tau3                =  fs->make<TH1D>("h_ak12chs_tau3"                   ,"",100,0,  1); 
+  h_ak12chs_tau4                =  fs->make<TH1D>("h_ak12chs_tau4"                   ,"",100,0,  1); 
+  h_ak12chs_tau32               =  fs->make<TH1D>("h_ak12chs_tau32"                  ,"",100,0,  1); 
+  h_ak12chs_tau21               =  fs->make<TH1D>("h_ak12chs_tau21"                  ,"",100,0,  1); 
+  h_ak12chs_ndau                =  fs->make<TH1D>("h_ak12chs_ndau"                   ,"",300,0,300); 
+  h_ak12chs_subjetMass          =  fs->make<TH1D>("h_ak12chs_subjetMass"             ,"",100,0,400); 
+  h_ak12chs_area                =  fs->make<TH1D>("h_ak12chs_area"                   ,"",100,0,  8); 
+  h_ak12chs_pt200_mass          =  fs->make<TH1D>("h_ak12chs_pt200_mass"             ,"",100,0,500); 
+  h_ak12chs_pt200_prunedMass    =  fs->make<TH1D>("h_ak12chs_pt200_prunedMass"       ,"",100,0,500); 
+  h_ak12chs_pt200_trimmedMass   =  fs->make<TH1D>("h_ak12chs_pt200_trimmedMass"      ,"",100,0,500); 
+  h_ak12chs_pt200_filteredMass  =  fs->make<TH1D>("h_ak12chs_pt200_filteredMass"     ,"",100,0,500); 
+  h_ak12chs_pt200_softDropMass  =  fs->make<TH1D>("h_ak12chs_pt200_softDropMass"     ,"",100,0,500); 
+  h_ak12chs_pt200_tau32         =  fs->make<TH1D>("h_ak12chs_pt200_tau32"            ,"",100,0,  1); 
+  h_ak12chs_pt200_tau21         =  fs->make<TH1D>("h_ak12chs_pt200_tau21"            ,"",100,0,  1); 
+  h_ak12chs_pt200_subjetMass    =  fs->make<TH1D>("h_ak12chs_pt200_subjetMass"       ,"",100,0,400); 
+  h_ak12chs_pt500_mass          =  fs->make<TH1D>("h_ak12chs_pt500_mass"             ,"",100,0,500); 
+  h_ak12chs_pt500_prunedMass    =  fs->make<TH1D>("h_ak12chs_pt500_prunedMass"       ,"",100,0,500); 
+  h_ak12chs_pt500_trimmedMass   =  fs->make<TH1D>("h_ak12chs_pt500_trimmedMass"      ,"",100,0,500); 
+  h_ak12chs_pt500_filteredMass  =  fs->make<TH1D>("h_ak12chs_pt500_filteredMass"     ,"",100,0,500); 
+  h_ak12chs_pt500_softDropMass  =  fs->make<TH1D>("h_ak12chs_pt500_softDropMass"     ,"",100,0,500); 
+  h_ak12chs_pt500_tau32         =  fs->make<TH1D>("h_ak12chs_pt500_tau32"            ,"",100,0,  1); 
+  h_ak12chs_pt500_tau21         =  fs->make<TH1D>("h_ak12chs_pt500_tau21"            ,"",100,0,  1); 
+  h_ak12chs_pt500_subjetMass    =  fs->make<TH1D>("h_ak12chs_pt500_subjetMass"       ,"",100,0,400); 
+
+
+
+  h_ak15chs_pt                  =  fs->make<TH1D>("h_ak15chs_pt"                     ,"",100,0,3000); 
+  h_ak15chs_mass                =  fs->make<TH1D>("h_ak15chs_mass"                   ,"",100,0,500); 
+  h_ak15chs_rapidity            =  fs->make<TH1D>("h_ak15chs_rapidity"               ,"",100,-5, 5); 
+  h_ak15chs_prunedMass          =  fs->make<TH1D>("h_ak15chs_prunedMass"             ,"",100,0,500); 
+  h_ak15chs_trimmedMass         =  fs->make<TH1D>("h_ak15chs_trimmedMass"            ,"",100,0,500); 
+  h_ak15chs_filteredMass        =  fs->make<TH1D>("h_ak15chs_filteredMass"           ,"",100,0,500); 
+  h_ak15chs_softDropMass        =  fs->make<TH1D>("h_ak15chs_softDropMass"           ,"",100,0,500); 
+  h_ak15chs_tau1                =  fs->make<TH1D>("h_ak15chs_tau1"                   ,"",100,0,  1); 
+  h_ak15chs_tau2                =  fs->make<TH1D>("h_ak15chs_tau2"                   ,"",100,0,  1); 
+  h_ak15chs_tau3                =  fs->make<TH1D>("h_ak15chs_tau3"                   ,"",100,0,  1); 
+  h_ak15chs_tau4                =  fs->make<TH1D>("h_ak15chs_tau4"                   ,"",100,0,  1); 
+  h_ak15chs_tau32               =  fs->make<TH1D>("h_ak15chs_tau32"                  ,"",100,0,  1); 
+  h_ak15chs_tau21               =  fs->make<TH1D>("h_ak15chs_tau21"                  ,"",100,0,  1); 
+  h_ak15chs_ndau                =  fs->make<TH1D>("h_ak15chs_ndau"                   ,"",300,0,300); 
+  h_ak15chs_subjetMass          =  fs->make<TH1D>("h_ak15chs_subjetMass"             ,"",100,0,400); 
+  h_ak15chs_area                =  fs->make<TH1D>("h_ak15chs_area"                   ,"",100,0,  8); 
+  h_ak15chs_pt200_mass          =  fs->make<TH1D>("h_ak15chs_pt200_mass"             ,"",100,0,500); 
+  h_ak15chs_pt200_prunedMass    =  fs->make<TH1D>("h_ak15chs_pt200_prunedMass"       ,"",100,0,500); 
+  h_ak15chs_pt200_trimmedMass   =  fs->make<TH1D>("h_ak15chs_pt200_trimmedMass"      ,"",100,0,500); 
+  h_ak15chs_pt200_filteredMass  =  fs->make<TH1D>("h_ak15chs_pt200_filteredMass"     ,"",100,0,500); 
+  h_ak15chs_pt200_softDropMass  =  fs->make<TH1D>("h_ak15chs_pt200_softDropMass"     ,"",100,0,500); 
+  h_ak15chs_pt200_tau32         =  fs->make<TH1D>("h_ak15chs_pt200_tau32"            ,"",100,0,  1); 
+  h_ak15chs_pt200_tau21         =  fs->make<TH1D>("h_ak15chs_pt200_tau21"            ,"",100,0,  1); 
+  h_ak15chs_pt200_subjetMass    =  fs->make<TH1D>("h_ak15chs_pt200_subjetMass"       ,"",100,0,400); 
+  h_ak15chs_pt500_mass          =  fs->make<TH1D>("h_ak15chs_pt500_mass"             ,"",100,0,500); 
+  h_ak15chs_pt500_prunedMass    =  fs->make<TH1D>("h_ak15chs_pt500_prunedMass"       ,"",100,0,500); 
+  h_ak15chs_pt500_trimmedMass   =  fs->make<TH1D>("h_ak15chs_pt500_trimmedMass"      ,"",100,0,500); 
+  h_ak15chs_pt500_filteredMass  =  fs->make<TH1D>("h_ak15chs_pt500_filteredMass"     ,"",100,0,500); 
+  h_ak15chs_pt500_softDropMass  =  fs->make<TH1D>("h_ak15chs_pt500_softDropMass"     ,"",100,0,500); 
+  h_ak15chs_pt500_tau32         =  fs->make<TH1D>("h_ak15chs_pt500_tau32"            ,"",100,0,  1); 
+  h_ak15chs_pt500_tau21         =  fs->make<TH1D>("h_ak15chs_pt500_tau21"            ,"",100,0,  1); 
+  h_ak15chs_pt500_subjetMass    =  fs->make<TH1D>("h_ak15chs_pt500_subjetMass"       ,"",100,0,400); 
+
+
+
+
+}
+
+
+JetTester::~JetTester()
+{
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+JetTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+  using namespace std;
+  using namespace reco;
+  using namespace pat;
+  bool verbose = false;
+
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=0.4 jets - from toolbox
+
+  edm::Handle<pat::JetCollection> AK4CHS;
+  iEvent.getByToken(ak4PFCHSjetToken_, AK4CHS);
+
+  edm::Handle<pat::JetCollection> AK4CHSsub;
+  iEvent.getByToken(ak4PFCHSSoftDropSubjetsToken_, AK4CHSsub);
+
+  int count_AK4CHS = 0;
+  for (const pat::Jet &ijet : *AK4CHS) {  
+    count_AK4CHS++;
+    if (count_AK4CHS>=2) break;
+    double pt           = ijet.pt();
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double prunedMass   = ijet.userFloat("ak4PFJetsCHSPrunedMass");
+    double trimmedMass  = ijet.userFloat("ak4PFJetsCHSTrimmedMass");
+    double filteredMass = ijet.userFloat("ak4PFJetsCHSFilteredMass");
+    double softDropMass = ijet.userFloat("ak4PFJetsCHSSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessAK4CHS:tau1");
+    double tau2         = ijet.userFloat("NjettinessAK4CHS:tau2");
+    double tau3         = ijet.userFloat("NjettinessAK4CHS:tau3");
+    double tau4         = ijet.userFloat("NjettinessAK4CHS:tau4");
+    double ndau         = ijet.numberOfDaughters();
+    double tau21 = 99;
+    double tau32 = 99;
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+   
+    double mostMassiveSDsubjetMass = 0;
+    for (const pat::Jet &isub : *AK4CHSsub) {  
+      double subjetEta      = isub.eta();
+      double subjetPhi      = isub.phi();
+      double subjetMass     = isub.mass();
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (deltaRsubjetJet<0.4){
+        if (verbose) cout<<"matched subjet with mass "<< subjetMass<<endl;
+        if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+      }
+    }
+
+    h_ak4chs_pt           ->Fill( pt           );
+    h_ak4chs_mass         ->Fill( mass         );
+    h_ak4chs_rapidity     ->Fill( rapidity     );
+    h_ak4chs_prunedMass   ->Fill( prunedMass   );
+    h_ak4chs_trimmedMass  ->Fill( trimmedMass  );
+    h_ak4chs_filteredMass ->Fill( filteredMass );
+    h_ak4chs_softDropMass ->Fill( softDropMass );
+    h_ak4chs_tau1         ->Fill( tau1         );
+    h_ak4chs_tau2         ->Fill( tau2         );
+    h_ak4chs_tau3         ->Fill( tau3         );
+    h_ak4chs_tau4         ->Fill( tau4         );
+    h_ak4chs_tau32        ->Fill( tau32        );
+    h_ak4chs_tau21        ->Fill( tau21        );
+    h_ak4chs_ndau         ->Fill( ndau         );
+    h_ak4chs_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    h_ak4chs_area         ->Fill( ijet.jetArea() );
+
+    if (pt>200){ 
+      h_ak4chs_pt200_mass         ->Fill( mass                            );
+      h_ak4chs_pt200_prunedMass   ->Fill( prunedMass                      );
+      h_ak4chs_pt200_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak4chs_pt200_filteredMass ->Fill( filteredMass                    );
+      h_ak4chs_pt200_softDropMass ->Fill( softDropMass                    );
+      h_ak4chs_pt200_tau32        ->Fill( tau32                           );
+      h_ak4chs_pt200_tau21        ->Fill( tau21                           );
+      h_ak4chs_pt200_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+    if (pt>500){ 
+      h_ak4chs_pt500_mass         ->Fill( mass                            );
+      h_ak4chs_pt500_prunedMass   ->Fill( prunedMass                      );
+      h_ak4chs_pt500_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak4chs_pt500_filteredMass ->Fill( filteredMass                    );
+      h_ak4chs_pt500_softDropMass ->Fill( softDropMass                    );
+      h_ak4chs_pt500_tau32        ->Fill( tau32                           );
+      h_ak4chs_pt500_tau21        ->Fill( tau21                           );
+      h_ak4chs_pt500_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+  }
+
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=0.8 PF jets - from toolbox
+
+  edm::Handle<pat::JetCollection> AK8PF;
+  iEvent.getByToken(ak8PFCHSjetToken_, AK8PF);
+
+  edm::Handle<pat::JetCollection> AK8PFsub;
+  iEvent.getByToken(ak8PFCHSSoftDropSubjetsToken_, AK8PFsub);
+
+  int count_AK8PF = 0;
+  for (const pat::Jet &ijet : *AK8PF) {  
+    count_AK8PF++;
+    if (count_AK8PF>=2) break;  
+    double pt           = ijet.pt();
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double prunedMass   = ijet.userFloat("ak8PFJetsCHSPrunedMass");
+    double trimmedMass  = ijet.userFloat("ak8PFJetsCHSTrimmedMass");
+    double filteredMass = ijet.userFloat("ak8PFJetsCHSFilteredMass");
+    double softDropMass = ijet.userFloat("ak8PFJetsCHSSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessAK8CHS:tau1");
+    double tau2         = ijet.userFloat("NjettinessAK8CHS:tau2");
+    double tau3         = ijet.userFloat("NjettinessAK8CHS:tau3");
+    double tau4         = ijet.userFloat("NjettinessAK8CHS:tau4");
+    double ndau         = ijet.numberOfDaughters();
+    double tau21 = 99;
+    double tau32 = 99;
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+   
+    double mostMassiveSDsubjetMass = 0;
+    for (const pat::Jet &isub : *AK8PFsub) {  
+      double subjetEta      = isub.eta();
+      double subjetPhi      = isub.phi();
+      double subjetMass     = isub.mass();
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (deltaRsubjetJet<0.8){
+        if (verbose) cout<<"matched subjet with mass "<< subjetMass<<endl;
+        if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+      }
+    }
+
+    h_ak8pf_pt           ->Fill( pt           );
+    h_ak8pf_mass         ->Fill( mass         );
+    h_ak8pf_rapidity     ->Fill( rapidity     );
+    h_ak8pf_prunedMass   ->Fill( prunedMass   );
+    h_ak8pf_trimmedMass  ->Fill( trimmedMass  );
+    h_ak8pf_filteredMass ->Fill( filteredMass );
+    h_ak8pf_softDropMass ->Fill( softDropMass );
+    h_ak8pf_tau1         ->Fill( tau1         );
+    h_ak8pf_tau2         ->Fill( tau2         );
+    h_ak8pf_tau3         ->Fill( tau3         );
+    h_ak8pf_tau4         ->Fill( tau4         );
+    h_ak8pf_tau32        ->Fill( tau32        );
+    h_ak8pf_tau21        ->Fill( tau21        );
+    h_ak8pf_ndau         ->Fill( ndau         );
+    h_ak8pf_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    h_ak8pf_area         ->Fill( ijet.jetArea() );
+
+    if (pt>200){ 
+      h_ak8pf_pt200_mass         ->Fill( mass                            );
+      h_ak8pf_pt200_prunedMass   ->Fill( prunedMass                      );
+      h_ak8pf_pt200_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak8pf_pt200_filteredMass ->Fill( filteredMass                    );
+      h_ak8pf_pt200_softDropMass ->Fill( softDropMass                    );
+      h_ak8pf_pt200_tau32        ->Fill( tau32                           );
+      h_ak8pf_pt200_tau21        ->Fill( tau21                           );
+      h_ak8pf_pt200_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+    if (pt>500){ 
+      h_ak8pf_pt500_mass         ->Fill( mass                            );
+      h_ak8pf_pt500_prunedMass   ->Fill( prunedMass                      );
+      h_ak8pf_pt500_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak8pf_pt500_filteredMass ->Fill( filteredMass                    );
+      h_ak8pf_pt500_softDropMass ->Fill( softDropMass                    );
+      h_ak8pf_pt500_tau32        ->Fill( tau32                           );
+      h_ak8pf_pt500_tau21        ->Fill( tau21                           );
+      h_ak8pf_pt500_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+  }
+  
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=0.8 CHS jets - from toolbox
+
+  edm::Handle<pat::JetCollection> AK8CHS;
+  iEvent.getByToken(ak8PFCHSjetToken_, AK8CHS);
+
+  edm::Handle<pat::JetCollection> AK8CHSsub;
+  iEvent.getByToken(ak8PFCHSSoftDropSubjetsToken_, AK8CHSsub);
+
+  int count_AK8CHS = 0;
+  for (const pat::Jet &ijet : *AK8CHS) {  
+    count_AK8CHS++;
+    if (count_AK8CHS>=2) break; 
+    double pt           = ijet.pt();
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double prunedMass   = ijet.userFloat("ak8PFJetsCHSPrunedMass");
+    double trimmedMass  = ijet.userFloat("ak8PFJetsCHSTrimmedMass");
+    double filteredMass = ijet.userFloat("ak8PFJetsCHSFilteredMass");
+    double softDropMass = ijet.userFloat("ak8PFJetsCHSSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessAK8CHS:tau1");
+    double tau2         = ijet.userFloat("NjettinessAK8CHS:tau2");
+    double tau3         = ijet.userFloat("NjettinessAK8CHS:tau3");
+    double tau4         = ijet.userFloat("NjettinessAK8CHS:tau4");
+    double ndau         = ijet.numberOfDaughters();
+    double tau21 = 99;
+    double tau32 = 99;
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+   
+    double mostMassiveSDsubjetMass = 0;
+    for (const pat::Jet &isub : *AK8CHSsub) {  
+      double subjetEta      = isub.eta();
+      double subjetPhi      = isub.phi();
+      double subjetMass     = isub.mass();
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (deltaRsubjetJet<0.8){
+        if (verbose) cout<<"matched subjet with mass "<< subjetMass<<endl;
+        if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+      }
+    }
+
+    h_ak8chs_pt           ->Fill( pt           );
+    h_ak8chs_mass         ->Fill( mass         );
+    h_ak8chs_rapidity     ->Fill( rapidity     );
+    h_ak8chs_prunedMass   ->Fill( prunedMass   );
+    h_ak8chs_trimmedMass  ->Fill( trimmedMass  );
+    h_ak8chs_filteredMass ->Fill( filteredMass );
+    h_ak8chs_softDropMass ->Fill( softDropMass );
+    h_ak8chs_tau1         ->Fill( tau1         );
+    h_ak8chs_tau2         ->Fill( tau2         );
+    h_ak8chs_tau3         ->Fill( tau3         );
+    h_ak8chs_tau4         ->Fill( tau4         );
+    h_ak8chs_tau32        ->Fill( tau32        );
+    h_ak8chs_tau21        ->Fill( tau21        );
+    h_ak8chs_ndau         ->Fill( ndau         );
+    h_ak8chs_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    h_ak8chs_area         ->Fill( ijet.jetArea() );
+
+    if (pt>200){ 
+      h_ak8chs_pt200_mass         ->Fill( mass                            );
+      h_ak8chs_pt200_prunedMass   ->Fill( prunedMass                      );
+      h_ak8chs_pt200_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak8chs_pt200_filteredMass ->Fill( filteredMass                    );
+      h_ak8chs_pt200_softDropMass ->Fill( softDropMass                    );
+      h_ak8chs_pt200_tau32        ->Fill( tau32                           );
+      h_ak8chs_pt200_tau21        ->Fill( tau21                           );
+      h_ak8chs_pt200_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+    if (pt>500){ 
+      h_ak8chs_pt500_mass         ->Fill( mass                            );
+      h_ak8chs_pt500_prunedMass   ->Fill( prunedMass                      );
+      h_ak8chs_pt500_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak8chs_pt500_filteredMass ->Fill( filteredMass                    );
+      h_ak8chs_pt500_softDropMass ->Fill( softDropMass                    );
+      h_ak8chs_pt500_tau32        ->Fill( tau32                           );
+      h_ak8chs_pt500_tau21        ->Fill( tau21                           );
+      h_ak8chs_pt500_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+  }
+  
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=0.8 PUPPI jets - from toolbox
+
+  edm::Handle<pat::JetCollection> AK8PUPPI;
+  iEvent.getByToken(ak8PFPUPPIjetToken_, AK8PUPPI);
+
+  edm::Handle<pat::JetCollection> AK8PUPPIsub;
+  iEvent.getByToken(ak8PFPUPPISoftDropSubjetsToken_, AK8PUPPIsub);
+
+  int count_AK8PUPPI = 0;
+  for (const pat::Jet &ijet : *AK8PUPPI) {  
+    count_AK8PUPPI++;
+    if (count_AK8PUPPI>=2) break;    
+    double pt           = ijet.pt();
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double prunedMass   = ijet.userFloat("ak8PFJetsPuppiPrunedMass");
+    double trimmedMass  = ijet.userFloat("ak8PFJetsPuppiTrimmedMass");
+    double filteredMass = ijet.userFloat("ak8PFJetsPuppiFilteredMass");
+    double softDropMass = ijet.userFloat("ak8PFJetsPuppiSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessAK8Puppi:tau1");
+    double tau2         = ijet.userFloat("NjettinessAK8Puppi:tau2");
+    double tau3         = ijet.userFloat("NjettinessAK8Puppi:tau3");
+    double tau4         = ijet.userFloat("NjettinessAK8Puppi:tau4");
+    double ndau         = ijet.numberOfDaughters();
+    double tau21 = 99;
+    double tau32 = 99;
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+   
+    double mostMassiveSDsubjetMass = 0;
+    for (const pat::Jet &isub : *AK8PUPPIsub) {  
+      double subjetEta      = isub.eta();
+      double subjetPhi      = isub.phi();
+      double subjetMass     = isub.mass();
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (deltaRsubjetJet<0.8){
+        if (verbose) cout<<"matched subjet with mass "<< subjetMass<<endl;
+        if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+      }
+    }
+
+    h_ak8puppi_pt           ->Fill( pt           );
+    h_ak8puppi_mass         ->Fill( mass         );
+    h_ak8puppi_rapidity     ->Fill( rapidity     );
+    h_ak8puppi_prunedMass   ->Fill( prunedMass   );
+    h_ak8puppi_trimmedMass  ->Fill( trimmedMass  );
+    h_ak8puppi_filteredMass ->Fill( filteredMass );
+    h_ak8puppi_softDropMass ->Fill( softDropMass );
+    h_ak8puppi_tau1         ->Fill( tau1         );
+    h_ak8puppi_tau2         ->Fill( tau2         );
+    h_ak8puppi_tau3         ->Fill( tau3         );
+    h_ak8puppi_tau4         ->Fill( tau4         );
+    h_ak8puppi_tau32        ->Fill( tau32        );
+    h_ak8puppi_tau21        ->Fill( tau21        );
+    h_ak8puppi_ndau         ->Fill( ndau         );
+    h_ak8puppi_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    h_ak8puppi_area         ->Fill( ijet.jetArea() );
+
+    if (pt>200){ 
+      h_ak8puppi_pt200_mass         ->Fill( mass                            );
+      h_ak8puppi_pt200_prunedMass   ->Fill( prunedMass                      );
+      h_ak8puppi_pt200_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak8puppi_pt200_filteredMass ->Fill( filteredMass                    );
+      h_ak8puppi_pt200_softDropMass ->Fill( softDropMass                    );
+      h_ak8puppi_pt200_tau32        ->Fill( tau32                           );
+      h_ak8puppi_pt200_tau21        ->Fill( tau21                           );
+      h_ak8puppi_pt200_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+    if (pt>500){ 
+      h_ak8puppi_pt500_mass         ->Fill( mass                            );
+      h_ak8puppi_pt500_prunedMass   ->Fill( prunedMass                      );
+      h_ak8puppi_pt500_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak8puppi_pt500_filteredMass ->Fill( filteredMass                    );
+      h_ak8puppi_pt500_softDropMass ->Fill( softDropMass                    );
+      h_ak8puppi_pt500_tau32        ->Fill( tau32                           );
+      h_ak8puppi_pt500_tau21        ->Fill( tau21                           );
+      h_ak8puppi_pt500_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+  }
+
+  //--------------------------------------------------------------------------------------------
+  // CA R=0.8 jets - from toolbox
+
+  edm::Handle<pat::JetCollection> CA8CHS;
+  iEvent.getByToken(ca8PFCHSjetToken_, CA8CHS);
+
+  edm::Handle<pat::JetCollection> CA8CHSsub;
+  iEvent.getByToken(ca8PFCHSSoftDropSubjetsToken_, CA8CHSsub);
+
+  int count_CA8CHS = 0;
+  for (const pat::Jet &ijet : *CA8CHS) {  
+    count_CA8CHS++;
+    if (count_CA8CHS>=2) break;   
+    double pt           = ijet.pt();
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double prunedMass   = ijet.userFloat("ca8PFJetsCHSPrunedMass");
+    double trimmedMass  = ijet.userFloat("ca8PFJetsCHSTrimmedMass");
+    double filteredMass = ijet.userFloat("ca8PFJetsCHSFilteredMass");
+    double softDropMass = ijet.userFloat("ca8PFJetsCHSSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessCA8CHS:tau1");
+    double tau2         = ijet.userFloat("NjettinessCA8CHS:tau2");
+    double tau3         = ijet.userFloat("NjettinessCA8CHS:tau3");
+    double tau4         = ijet.userFloat("NjettinessCA8CHS:tau4");
+    double ndau         = ijet.numberOfDaughters();
+    double tau21 = 99;
+    double tau32 = 99;
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+   
+    double mostMassiveSDsubjetMass = 0;
+    for (const pat::Jet &isub : *CA8CHSsub) {  
+      double subjetEta      = isub.eta();
+      double subjetPhi      = isub.phi();
+      double subjetMass     = isub.mass();
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (deltaRsubjetJet<0.8){
+        if (verbose) cout<<"matched subjet with mass "<< subjetMass<<endl;
+        if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+      }
+    }
+
+    h_ca8chs_pt           ->Fill( pt           );
+    h_ca8chs_mass         ->Fill( mass         );
+    h_ca8chs_rapidity     ->Fill( rapidity     );
+    h_ca8chs_prunedMass   ->Fill( prunedMass   );
+    h_ca8chs_trimmedMass  ->Fill( trimmedMass  );
+    h_ca8chs_filteredMass ->Fill( filteredMass );
+    h_ca8chs_softDropMass ->Fill( softDropMass );
+    h_ca8chs_tau1         ->Fill( tau1         );
+    h_ca8chs_tau2         ->Fill( tau2         );
+    h_ca8chs_tau3         ->Fill( tau3         );
+    h_ca8chs_tau4         ->Fill( tau4         );
+    h_ca8chs_tau32        ->Fill( tau32        );
+    h_ca8chs_tau21        ->Fill( tau21        );
+    h_ca8chs_ndau         ->Fill( ndau         );
+    h_ca8chs_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    h_ca8chs_area         ->Fill( ijet.jetArea() );
+
+    if (pt>200){ 
+      h_ca8chs_pt200_mass         ->Fill( mass                            );
+      h_ca8chs_pt200_prunedMass   ->Fill( prunedMass                      );
+      h_ca8chs_pt200_trimmedMass  ->Fill( trimmedMass                     );
+      h_ca8chs_pt200_filteredMass ->Fill( filteredMass                    );
+      h_ca8chs_pt200_softDropMass ->Fill( softDropMass                    );
+      h_ca8chs_pt200_tau32        ->Fill( tau32                           );
+      h_ca8chs_pt200_tau21        ->Fill( tau21                           );
+      h_ca8chs_pt200_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+    if (pt>500){ 
+      h_ca8chs_pt500_mass         ->Fill( mass                            );
+      h_ca8chs_pt500_prunedMass   ->Fill( prunedMass                      );
+      h_ca8chs_pt500_trimmedMass  ->Fill( trimmedMass                     );
+      h_ca8chs_pt500_filteredMass ->Fill( filteredMass                    );
+      h_ca8chs_pt500_softDropMass ->Fill( softDropMass                    );
+      h_ca8chs_pt500_tau32        ->Fill( tau32                           );
+      h_ca8chs_pt500_tau21        ->Fill( tau21                           );
+      h_ca8chs_pt500_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+  }
+  
+
+  //--------------------------------------------------------------------------------------------
+  // KT R=0.8 jets - from toolbox
+
+  edm::Handle<pat::JetCollection> KT8CHS;
+  iEvent.getByToken(kt8PFCHSjetToken_, KT8CHS);
+
+  edm::Handle<pat::JetCollection> KT8CHSsub;
+  iEvent.getByToken(kt8PFCHSSoftDropSubjetsToken_, KT8CHSsub);
+
+  int count_KT8CHS = 0;
+  for (const pat::Jet &ijet : *KT8CHS) {  
+    count_KT8CHS++;
+    if (count_KT8CHS>=2) break;   
+    double pt           = ijet.pt();
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double prunedMass   = ijet.userFloat("kt8PFJetsCHSPrunedMass");
+    double trimmedMass  = ijet.userFloat("kt8PFJetsCHSTrimmedMass");
+    double filteredMass = ijet.userFloat("kt8PFJetsCHSFilteredMass");
+    double softDropMass = ijet.userFloat("kt8PFJetsCHSSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessKT8CHS:tau1");
+    double tau2         = ijet.userFloat("NjettinessKT8CHS:tau2");
+    double tau3         = ijet.userFloat("NjettinessKT8CHS:tau3");
+    double tau4         = ijet.userFloat("NjettinessKT8CHS:tau4");
+    double ndau         = ijet.numberOfDaughters();
+    double tau21 = 99;
+    double tau32 = 99;
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+   
+    double mostMassiveSDsubjetMass = 0;
+    for (const pat::Jet &isub : *KT8CHSsub) {  
+      double subjetEta      = isub.eta();
+      double subjetPhi      = isub.phi();
+      double subjetMass     = isub.mass();
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (deltaRsubjetJet<0.8){
+        if (verbose) cout<<"matched subjet with mass "<< subjetMass<<endl;
+        if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+      }
+    }
+
+    h_kt8chs_pt           ->Fill( pt           );
+    h_kt8chs_mass         ->Fill( mass         );
+    h_kt8chs_rapidity     ->Fill( rapidity     );
+    h_kt8chs_prunedMass   ->Fill( prunedMass   );
+    h_kt8chs_trimmedMass  ->Fill( trimmedMass  );
+    h_kt8chs_filteredMass ->Fill( filteredMass );
+    h_kt8chs_softDropMass ->Fill( softDropMass );
+    h_kt8chs_tau1         ->Fill( tau1         );
+    h_kt8chs_tau2         ->Fill( tau2         );
+    h_kt8chs_tau3         ->Fill( tau3         );
+    h_kt8chs_tau4         ->Fill( tau4         );
+    h_kt8chs_tau32        ->Fill( tau32        );
+    h_kt8chs_tau21        ->Fill( tau21        );
+    h_kt8chs_ndau         ->Fill( ndau         );
+    h_kt8chs_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    h_kt8chs_area         ->Fill( ijet.jetArea() );
+
+    if (pt>200){ 
+      h_kt8chs_pt200_mass         ->Fill( mass                            );
+      h_kt8chs_pt200_prunedMass   ->Fill( prunedMass                      );
+      h_kt8chs_pt200_trimmedMass  ->Fill( trimmedMass                     );
+      h_kt8chs_pt200_filteredMass ->Fill( filteredMass                    );
+      h_kt8chs_pt200_softDropMass ->Fill( softDropMass                    );
+      h_kt8chs_pt200_tau32        ->Fill( tau32                           );
+      h_kt8chs_pt200_tau21        ->Fill( tau21                           );
+      h_kt8chs_pt200_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+    if (pt>500){ 
+      h_kt8chs_pt500_mass         ->Fill( mass                            );
+      h_kt8chs_pt500_prunedMass   ->Fill( prunedMass                      );
+      h_kt8chs_pt500_trimmedMass  ->Fill( trimmedMass                     );
+      h_kt8chs_pt500_filteredMass ->Fill( filteredMass                    );
+      h_kt8chs_pt500_softDropMass ->Fill( softDropMass                    );
+      h_kt8chs_pt500_tau32        ->Fill( tau32                           );
+      h_kt8chs_pt500_tau21        ->Fill( tau21                           );
+      h_kt8chs_pt500_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+  }
+  
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=1.2 jets - from toolbox
+
+  edm::Handle<pat::JetCollection> AK12CHS;
+  iEvent.getByToken(ak12PFCHSjetToken_, AK12CHS);
+
+  edm::Handle<pat::JetCollection> AK12CHSsub;
+  iEvent.getByToken(ak12PFCHSSoftDropSubjetsToken_, AK12CHSsub);
+
+  int count_AK12CHS = 0;
+  for (const pat::Jet &ijet : *AK12CHS) {  
+    count_AK12CHS++;
+    if (count_AK12CHS>=2) break; 
+    double pt           = ijet.pt();
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double prunedMass   = ijet.userFloat("ak12PFJetsCHSPrunedMass");
+    double trimmedMass  = ijet.userFloat("ak12PFJetsCHSTrimmedMass");
+    double filteredMass = ijet.userFloat("ak12PFJetsCHSFilteredMass");
+    double softDropMass = ijet.userFloat("ak12PFJetsCHSSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessAK12CHS:tau1");
+    double tau2         = ijet.userFloat("NjettinessAK12CHS:tau2");
+    double tau3         = ijet.userFloat("NjettinessAK12CHS:tau3");
+    double tau4         = ijet.userFloat("NjettinessAK12CHS:tau4");
+    double ndau         = ijet.numberOfDaughters();
+    double tau21 = 99;
+    double tau32 = 99;
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+   
+    double mostMassiveSDsubjetMass = 0;
+    for (const pat::Jet &isub : *AK12CHSsub) {  
+      double subjetEta      = isub.eta();
+      double subjetPhi      = isub.phi();
+      double subjetMass     = isub.mass();
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (deltaRsubjetJet<1.2){
+        if (verbose) cout<<"matched subjet with mass "<< subjetMass<<endl;
+        if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+      }
+    }
+
+    h_ak12chs_pt           ->Fill( pt           );
+    h_ak12chs_mass         ->Fill( mass         );
+    h_ak12chs_rapidity     ->Fill( rapidity     );
+    h_ak12chs_prunedMass   ->Fill( prunedMass   );
+    h_ak12chs_trimmedMass  ->Fill( trimmedMass  );
+    h_ak12chs_filteredMass ->Fill( filteredMass );
+    h_ak12chs_softDropMass ->Fill( softDropMass );
+    h_ak12chs_tau1         ->Fill( tau1         );
+    h_ak12chs_tau2         ->Fill( tau2         );
+    h_ak12chs_tau3         ->Fill( tau3         );
+    h_ak12chs_tau4         ->Fill( tau4         );
+    h_ak12chs_tau32        ->Fill( tau32        );
+    h_ak12chs_tau21        ->Fill( tau21        );
+    h_ak12chs_ndau         ->Fill( ndau         );
+    h_ak12chs_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    h_ak12chs_area         ->Fill( ijet.jetArea() );
+
+    if (pt>200){ 
+      h_ak12chs_pt200_mass         ->Fill( mass                            );
+      h_ak12chs_pt200_prunedMass   ->Fill( prunedMass                      );
+      h_ak12chs_pt200_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak12chs_pt200_filteredMass ->Fill( filteredMass                    );
+      h_ak12chs_pt200_softDropMass ->Fill( softDropMass                    );
+      h_ak12chs_pt200_tau32        ->Fill( tau32                           );
+      h_ak12chs_pt200_tau21        ->Fill( tau21                           );
+      h_ak12chs_pt200_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+    if (pt>500){ 
+      h_ak12chs_pt500_mass         ->Fill( mass                            );
+      h_ak12chs_pt500_prunedMass   ->Fill( prunedMass                      );
+      h_ak12chs_pt500_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak12chs_pt500_filteredMass ->Fill( filteredMass                    );
+      h_ak12chs_pt500_softDropMass ->Fill( softDropMass                    );
+      h_ak12chs_pt500_tau32        ->Fill( tau32                           );
+      h_ak12chs_pt500_tau21        ->Fill( tau21                           );
+      h_ak12chs_pt500_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+  }
+  
+
+
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=1.5 jets - from toolbox
+
+  edm::Handle<pat::JetCollection> AK15CHS;
+  iEvent.getByToken(ak15PFCHSjetToken_, AK15CHS);
+
+  edm::Handle<pat::JetCollection> AK15CHSsub;
+  iEvent.getByToken(ak15PFCHSSoftDropSubjetsToken_, AK15CHSsub);
+
+  int count_AK15CHS = 0;
+  for (const pat::Jet &ijet : *AK15CHS) {  
+    count_AK15CHS++;
+    if (count_AK15CHS>=2) break;     
+    double pt           = ijet.pt();
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double prunedMass   = ijet.userFloat("ak15PFJetsCHSPrunedMass");
+    double trimmedMass  = ijet.userFloat("ak15PFJetsCHSTrimmedMass");
+    double filteredMass = ijet.userFloat("ak15PFJetsCHSFilteredMass");
+    double softDropMass = ijet.userFloat("ak15PFJetsCHSSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessAK15CHS:tau1");
+    double tau2         = ijet.userFloat("NjettinessAK15CHS:tau2");
+    double tau3         = ijet.userFloat("NjettinessAK15CHS:tau3");
+    double tau4         = ijet.userFloat("NjettinessAK15CHS:tau4");
+    double ndau         = ijet.numberOfDaughters();
+    double tau21 = 99;
+    double tau32 = 99;
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+   
+    double mostMassiveSDsubjetMass = 0;
+    for (const pat::Jet &isub : *AK15CHSsub) {  
+      double subjetEta      = isub.eta();
+      double subjetPhi      = isub.phi();
+      double subjetMass     = isub.mass();
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (deltaRsubjetJet<1.5){
+        if (verbose) cout<<"matched subjet with mass "<< subjetMass<<endl;
+        if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+      }
+    }
+
+    h_ak15chs_pt           ->Fill( pt           );
+    h_ak15chs_mass         ->Fill( mass         );
+    h_ak15chs_rapidity     ->Fill( rapidity     );
+    h_ak15chs_prunedMass   ->Fill( prunedMass   );
+    h_ak15chs_trimmedMass  ->Fill( trimmedMass  );
+    h_ak15chs_filteredMass ->Fill( filteredMass );
+    h_ak15chs_softDropMass ->Fill( softDropMass );
+    h_ak15chs_tau1         ->Fill( tau1         );
+    h_ak15chs_tau2         ->Fill( tau2         );
+    h_ak15chs_tau3         ->Fill( tau3         );
+    h_ak15chs_tau4         ->Fill( tau4         );
+    h_ak15chs_tau32        ->Fill( tau32        );
+    h_ak15chs_tau21        ->Fill( tau21        );
+    h_ak15chs_ndau         ->Fill( ndau         );
+    h_ak15chs_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    h_ak15chs_area         ->Fill( ijet.jetArea() );
+
+    if (pt>200){ 
+      h_ak15chs_pt200_mass         ->Fill( mass                            );
+      h_ak15chs_pt200_prunedMass   ->Fill( prunedMass                      );
+      h_ak15chs_pt200_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak15chs_pt200_filteredMass ->Fill( filteredMass                    );
+      h_ak15chs_pt200_softDropMass ->Fill( softDropMass                    );
+      h_ak15chs_pt200_tau32        ->Fill( tau32                           );
+      h_ak15chs_pt200_tau21        ->Fill( tau21                           );
+      h_ak15chs_pt200_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+    if (pt>500){ 
+      h_ak15chs_pt500_mass         ->Fill( mass                            );
+      h_ak15chs_pt500_prunedMass   ->Fill( prunedMass                      );
+      h_ak15chs_pt500_trimmedMass  ->Fill( trimmedMass                     );
+      h_ak15chs_pt500_filteredMass ->Fill( filteredMass                    );
+      h_ak15chs_pt500_softDropMass ->Fill( softDropMass                    );
+      h_ak15chs_pt500_tau32        ->Fill( tau32                           );
+      h_ak15chs_pt500_tau21        ->Fill( tau21                           );
+      h_ak15chs_pt500_subjetMass   ->Fill( mostMassiveSDsubjetMass         );
+    }
+  }
+
+
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=0.8 jets - default miniAOD
+
+  edm::Handle<pat::JetCollection> AK8MINI;
+  iEvent.getByToken(ak8jetMiniToken_, AK8MINI);
+
+  edm::Handle<reco::GenJetCollection> AK8GENJET;  
+  iEvent.getByToken(ak8genjetToken_, AK8GENJET);
+
+  for (const pat::Jet &ijet : *AK8MINI) {  
+    double pt           = ijet.pt();
+    if (pt<400) continue;
+    double mass         = ijet.mass();
+    double rapidity     = ijet.rapidity();
+    double ndau         = ijet.numberOfDaughters();
+    double prunedMass   = ijet.userFloat("ak8PFJetsCHSValueMap:ak8PFJetsCHSPrunedMass");
+    double softDropMass = ijet.userFloat("ak8PFJetsCHSValueMap:ak8PFJetsCHSSoftDropMass");
+    double tau1         = ijet.userFloat("NjettinessAK8Puppi:tau1");
+    double tau2         = ijet.userFloat("NjettinessAK8Puppi:tau2");
+    double tau3         = ijet.userFloat("NjettinessAK8Puppi:tau3");
+    double tau21        = 99;
+    double tau32        = 99;
+
+    double puppi_pt           = ijet.pt();//userFloat("ak8PFJetsPuppiValueMap:pt");
+    double puppi_mass         = ijet.mass();//userFloat("ak8PFJetsPuppiValueMap:mass");
+    double puppi_eta          = ijet.eta();//userFloat("ak8PFJetsPuppiValueMap:eta");
+    double puppi_phi          = ijet.phi();//userFloat("ak8PFJetsPuppiValueMap:phi");
+    double puppi_tau1         = ijet.userFloat("NjettinessAK8Puppi:tau1");
+    double puppi_tau2         = ijet.userFloat("NjettinessAK8Puppi:tau2");
+    double puppi_tau3         = ijet.userFloat("NjettinessAK8Puppi:tau3");
+    double puppi_tau21        = 99;
+    double puppi_tau32        = 99;
+
+   
+    if (tau1!=0) tau21 = tau2/tau1;
+    if (tau2!=0) tau32 = tau3/tau2;
+
+    if (puppi_tau1!=0) puppi_tau21 = puppi_tau2/puppi_tau1;
+    if (puppi_tau2!=0) puppi_tau32 = puppi_tau3/puppi_tau2;
+
+    if (verbose) cout<<"\nJet with pT "<<pt<<" sdMass "<<softDropMass<<endl;
+
+    if (verbose) cout<<"tau21 "<<tau21<<endl;
+    if (verbose) cout<<"tau32 "<<tau32<<endl;
+
+    if (verbose) cout<<"puppi_tau21 "<<puppi_tau21<<endl;
+    if (verbose) cout<<"puppi_tau32 "<<puppi_tau32<<endl;
+
+    // Soft Drop + Nsubjettiness tagger
+    bool SoftDropTau32Tagged = false;
+    if (softDropMass<230 && softDropMass>140 && tau32 <0.65) SoftDropTau32Tagged = true;
+
+    // Get Soft drop subjets for subjet b-tagging
+    double mostMassiveSDsubjetMass = 0;
+    auto const & sdSubjets = ijet.subjets("SoftDropPuppi");
+    for ( auto const & it : sdSubjets ) {
+      double subjetPt       = it->pt();
+      double subjetPtUncorr = it->pt();
+      double subjetEta      = it->eta();
+      double subjetPhi      = it->phi();
+      double subjetMass     = it->mass();
+      double subjetBdisc    = it->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"); 
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (verbose) cout<<" SD Subjet pt "<<subjetPt<<" uncorr "<<subjetPtUncorr<<" Eta "<<subjetEta<<" deltaRsubjetJet "<<deltaRsubjetJet<<" Mass "<<subjetMass<<" Bdisc "<<subjetBdisc<<endl;
+      // h_ak8chs_sdSubjetMass ->Fill( subjetMass );
+      if (subjetMass > mostMassiveSDsubjetMass) mostMassiveSDsubjetMass = subjetMass;
+    }
+
+    // Get Soft drop PUPPI subjets 
+    TLorentzVector pup0;
+    TLorentzVector pup1;
+    double mostMassiveSDPUPPIsubjetMass = 0;
+    auto const & sdSubjetsPuppi = ijet.subjets("SoftDropPuppi");
+    int count_pup=0;
+    for ( auto const & it : sdSubjetsPuppi ) {
+      double subjetPt       = it->pt();
+      double subjetPtUncorr = it->pt();
+      double subjetEta      = it->eta();
+      double subjetPhi      = it->phi();
+      double subjetMass     = it->mass();
+      double subjetBdisc    = it->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"); 
+      double deltaRsubjetJet = deltaR(ijet.eta(), ijet.phi(), subjetEta, subjetPhi);
+      if (verbose) cout<<" SD Subjet pt "<<subjetPt<<" uncorr "<<subjetPtUncorr<<" Eta "<<subjetEta<<" deltaRsubjetJet "<<deltaRsubjetJet<<" Mass "<<subjetMass<<" Bdisc "<<subjetBdisc<<endl; 
+      // h_ak8puppi_sdSubjetMass ->Fill( subjetMass );
+      if (count_pup==0) pup0.SetPtEtaPhiM( subjetPt, subjetEta, subjetPhi, subjetMass);
+      if (count_pup==1) pup1.SetPtEtaPhiM( subjetPt, subjetEta, subjetPhi, subjetMass);
+      if (subjetMass > mostMassiveSDPUPPIsubjetMass) mostMassiveSDPUPPIsubjetMass = subjetMass;
+      count_pup++;
+    }
+
+    TLorentzVector puppiSD;
+    if (count_pup>1)
+    {
+      puppiSD = pup0 + pup1;
+      if (verbose) cout<<pup0.M()<<" "<<pup1.M()<<" "<<puppiSD.M()<<" "<<endl;
+    }
+
+    //Print some jet info
+    if (verbose && SoftDropTau32Tagged) cout<<"->SoftDropTau32Tagged"<<endl;
+    if (verbose){
+      cout<<"mass         "<<mass         <<endl;  
+      cout<<"rapidity     "<<rapidity     <<endl;  
+      cout<<"ndau         "<<ndau         <<endl;  
+      cout<<"prunedMass   "<<prunedMass   <<endl;  
+      cout<<"softDropMass "<<softDropMass <<endl;
+      cout<<"tau1         "<<tau1         <<endl;  
+      cout<<"tau2         "<<tau2         <<endl;  
+      cout<<"tau3         "<<tau3         <<endl;  
+      cout<<"tau21        "<<tau21        <<endl;  
+      cout<<"tau32        "<<tau32        <<endl;  
+      cout<<"puppi_pt     "<<puppi_pt     <<endl;  
+      cout<<"puppi_mass   "<<puppi_mass   <<endl;  
+      cout<<"puppi_eta    "<<puppi_eta    <<endl;  
+      cout<<"puppi_phi    "<<puppi_phi    <<endl;  
+      cout<<"puppi_tau1   "<<puppi_tau1   <<endl;  
+      cout<<"puppi_tau2   "<<puppi_tau2   <<endl;  
+      cout<<"puppi_tau3   "<<puppi_tau3   <<endl;  
+      cout<<"puppi_tau21  "<<puppi_tau21  <<endl;  
+      cout<<"puppi_tau32  "<<puppi_tau32  <<endl;  
+    }
+
+
+  }
+
+
+  // edm::Handle<std::vector<pat::Jet> > AK8MINI;
+  // iEvent.getByLabel( "slimmedJetsAK8", AK8MINI );
+  // edm::Handle<std::vector<pat::Jet> > AK8MINI_SD_Subjets;
+  // iEvent.getByLabel( "slimmedJetsAK8PFCHSSoftDropPacked", "SubJets", AK8MINI_SD_Subjets );
+  // edm::Handle<std::vector<pat::Jet> > AK8MINI_CMSTopTag_Subjets;
+  // iEvent.getByLabel( "slimmedJetsCMSTopTagCHSPacked", "SubJets", AK8MINI_CMSTopTag_Subjets );
+
+
+  // for ( std::vector<pat::Jet>::const_iterator jetBegin = AK8MINI_SD_Subjets->begin(), jetEnd = AK8MINI_SD_Subjets->end(), ijet = jetBegin; ijet != jetEnd; ++ijet ) 
+  // {
+  //       double pt           = ijet->pt();
+  //       double bdisc        = ijet->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+  //       cout<<"SD subjet pt "<<pt<<" bdisc "<<bdisc<<endl;
+  // }
+  // cout<<endl;
+  // for ( std::vector<pat::Jet>::const_iterator jetBegin = AK8MINI_CMSTopTag_Subjets->begin(), jetEnd = AK8MINI_CMSTopTag_Subjets->end(), ijet = jetBegin; ijet != jetEnd; ++ijet ) 
+  // {
+  //       double pt           = ijet->pt();
+  //       double bdisc        = ijet->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+  //       cout<<"CMSTT subjet pt "<<pt<<" bdisc "<<bdisc<<endl;
+  // }
+
+
+  // for ( std::vector<pat::Jet>::const_iterator jetBegin = AK8MINI->begin(), jetEnd = AK8MINI->end(), ijet = jetBegin; ijet != jetEnd; ++ijet ) 
+  // {
+  //   double pt           = ijet->pt();
+  //   if (pt<150) continue;
+  //   double mass         = ijet->mass();
+  //   double rapidity     = ijet->rapidity();
+  //   double prunedMass   = ijet->userFloat("ak8PFJetsCHSPrunedMass");
+  //   double trimmedMass  = ijet->userFloat("ak8PFJetsCHSTrimmedMass");
+  //   double filteredMass = ijet->userFloat("ak8PFJetsCHSFilteredMass");
+  //   double softDropMass = ijet->userFloat("ak8PFJetsCHSSoftDropMass");
+  //   double tau1         = ijet->userFloat("NjettinessAK8:tau1");
+  //   double tau2         = ijet->userFloat("NjettinessAK8:tau2");
+  //   double tau3         = ijet->userFloat("NjettinessAK8:tau3");
+  //   double ndau         = ijet->numberOfDaughters();
+
+  //   double tau21 = 99;
+  //   double tau32 = 99;
+  //   if (tau1!=2) tau21 = tau2/tau1;
+  //   if (tau2!=2) tau32 = tau3/tau2;
+
+  //   cout<<"\nJet with pT "<<pt<<" sdMass "<<softDropMass<<endl;
+
+
+  //   // Soft Drop + Nsubjettiness tagger
+  //   bool SoftDropTau32Tagged = false;
+  //   if (softDropMass<230 && softDropMass>140 && tau32 <0.65) SoftDropTau32Tagged = true;
+
+  //   //CMS Top Tagger
+  //   reco::CATopJetTagInfo const * tagInfo =  dynamic_cast<reco::CATopJetTagInfo const *>( ijet->tagInfo("caTop"));
+  //   bool Run1CMStopTagged = false;
+  //   int nSubJetsCATop = 0;
+  //   if ( tagInfo != 0 ) {
+  //     double minMass = tagInfo->properties().minMass;
+  //     double topMass = tagInfo->properties().topMass;
+  //     nSubJetsCATop = tagInfo->properties().nSubJets;
+  //     if ( nSubJetsCATop > 2 && minMass > 50.0 && topMass > 140.0 &&  topMass < 250.0 ) Run1CMStopTagged = true;  
+  //   }
+
+  //   // Get Soft drop subjets for subjet b-tagging
+  //   auto const & sdSubjets = ijet->subjets("SoftDrop");
+  //   cout<<"sdSubjets size "<<sdSubjets.size()<<endl;
+  //   for ( auto const & it : sdSubjets ) {
+  //     double subjetPt       = it->pt();
+  //     double subjetPtUncorr = it->pt();
+  //     double subjetEta      = it->eta();
+  //     double subjetPhi      = it->phi();
+  //     double subjetMass     = it->mass();
+  //     double subjetBdisc    = it->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"); 
+  //     double deltaRsubjetJet = deltaR(ijet->eta(), ijet->phi(), subjetEta, subjetPhi);
+  //     cout<<" SD Subjet pt "<<subjetPt<<" uncorr "<<subjetPtUncorr<<" Eta "<<subjetEta<<" deltaRsubjetJet "<<deltaRsubjetJet<<" Mass "<<subjetMass<<" Bdisc "<<subjetBdisc<<endl;
+  //   }
+
+  //   // Get top tagged subjets 
+  //   auto const & topSubjets = ijet->subjets("CMSTopTag");
+  //   cout<<"topSubjets size "<<topSubjets.size()<<endl;
+  //   int countTopSubjetLoop = 0;
+  //   for ( auto const & it : topSubjets ) {
+  //     countTopSubjetLoop++;
+  //     double subjetPt       = it->pt();
+  //     double subjetPtUncorr = it->pt();
+  //     double subjetEta      = it->eta();
+  //     double subjetPhi      = it->phi();
+  //     double subjetMass     = it->mass();
+  //     double subjetBdisc    = it->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"); 
+  //     double deltaRsubjetJet = deltaR(ijet->eta(), ijet->phi(), subjetEta, subjetPhi);
+  //     cout<<" CMSTT Subjet pt "<<subjetPt<<" uncorr "<<subjetPtUncorr<<" Eta "<<subjetEta<<" deltaRsubjetJet "<<deltaRsubjetJet<<" Mass "<<subjetMass<<" Bdisc "<<subjetBdisc<<endl;
+  //   }
+
+  //   cout<<"nSubJetsCATop     "<< nSubJetsCATop     <<endl;
+  //   cout<<"topSubjets.size() "<< topSubjets.size() <<endl;
+  //   cout<<"countSubjetLoop   "<< countTopSubjetLoop<<endl;
+
+  //   //Print some jet info
+  //   if (SoftDropTau32Tagged) cout<<"->SoftDropTau32Tagged"<<endl;
+  //   if (Run1CMStopTagged)    cout<<"->Run1CMStopTagged"<<endl;
+
+  //   // Fill histograms
+  //   h_ak8chs_pt           ->Fill( pt           );
+  //   h_ak8chs_mass         ->Fill( mass         );
+  //   h_ak8chs_rapidity     ->Fill( rapidity     );
+  //   h_ak8chs_prunedMass   ->Fill( prunedMass   );
+  //   h_ak8chs_trimmedMass  ->Fill( trimmedMass  );
+  //   h_ak8chs_filteredMass ->Fill( filteredMass );
+  //   h_ak8chs_softDropMass ->Fill( softDropMass );
+  //   h_ak8chs_tau1         ->Fill( tau1         );
+  //   h_ak8chs_tau2         ->Fill( tau2         );
+  //   h_ak8chs_tau3         ->Fill( tau3         );
+  //   h_ak8chs_tau32        ->Fill( tau32        );
+  //   h_ak8chs_tau21        ->Fill( tau21        );
+  //   h_ak8chs_ndau         ->Fill( ndau         );
+  // }
+/*
+  //--------------------------------------------------------------------------------------------
+  // AK R=0.8 PUPPI jets - from toolbox
+
+  edm::Handle<std::vector<pat::Jet> > AK8Puppi;
+  iEvent.getByLabel( "selectedPatJetsAK8PFPuppi", AK8Puppi );
+  for ( std::vector<pat::Jet>::const_iterator jetBegin = AK8Puppi->begin(), jetEnd = AK8Puppi->end(), ijet = jetBegin; ijet != jetEnd; ++ijet ) 
+  {
+    double pt           = ijet->pt();
+    if (pt<150) continue;
+    double mass         = ijet->mass();
+    double rapidity     = ijet->rapidity();
+    double prunedMass   = ijet->userFloat("ak8PFJetsPuppiPrunedMass");
+    double trimmedMass  = ijet->userFloat("ak8PFJetsPuppiTrimmedMass");
+    double filteredMass = ijet->userFloat("ak8PFJetsPuppiFilteredMass");
+    double softDropMass = ijet->userFloat("ak8PFJetsPuppiSoftDropMass");
+    double ndau         = ijet->numberOfDaughters();
+
+    h_ak8puppi_pt           ->Fill( pt           );
+    h_ak8puppi_mass         ->Fill( mass         );
+    h_ak8puppi_rapidity     ->Fill( rapidity     );
+    h_ak8puppi_prunedMass   ->Fill( prunedMass   );
+    h_ak8puppi_trimmedMass  ->Fill( trimmedMass  );
+    h_ak8puppi_filteredMass ->Fill( filteredMass );
+    h_ak8puppi_softDropMass ->Fill( softDropMass );
+    h_ak8puppi_ndau         ->Fill( ndau         );
+  }
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=0.8 PF jets - from toolbox
+
+  edm::Handle<std::vector<pat::Jet> > AK8PF;
+  iEvent.getByLabel( "selectedPatJetsAK8PF", AK8PF );
+  for ( std::vector<pat::Jet>::const_iterator jetBegin = AK8PF->begin(), jetEnd = AK8PF->end(), ijet = jetBegin; ijet != jetEnd; ++ijet ) 
+  {
+    double pt           = ijet->pt();
+    if (pt<150) continue;
+    double mass         = ijet->mass();
+    double rapidity     = ijet->rapidity();
+    double prunedMass   = ijet->userFloat("ak8PFJetsPrunedMass");
+    double trimmedMass  = ijet->userFloat("ak8PFJetsTrimmedMass");
+    double filteredMass = ijet->userFloat("ak8PFJetsFilteredMass");
+    double softDropMass = ijet->userFloat("ak8PFJetsSoftDropMass");
+    double ndau         = ijet->numberOfDaughters();
+
+    h_ak8pf_pt           ->Fill( pt           );
+    h_ak8pf_mass         ->Fill( mass         );
+    h_ak8pf_rapidity     ->Fill( rapidity     );
+    h_ak8pf_prunedMass   ->Fill( prunedMass   );
+    h_ak8pf_trimmedMass  ->Fill( trimmedMass  );
+    h_ak8pf_filteredMass ->Fill( filteredMass );
+    h_ak8pf_softDropMass ->Fill( softDropMass );
+    h_ak8pf_ndau         ->Fill( ndau         );
+  }
+
+
+  //--------------------------------------------------------------------------------------------
+  // AK R=0.8 CHS jets with modified grooming parameters - from toolbox
+
+  edm::Handle<std::vector<pat::Jet> > AK8CHS;
+  iEvent.getByLabel( "selectedPatJetsAK8PFCHS", AK8CHS );
+  for ( std::vector<pat::Jet>::const_iterator jetBegin = AK8CHS->begin(), jetEnd = AK8CHS->end(), ijet = jetBegin; ijet != jetEnd; ++ijet ) 
+  {
+    double pt           = ijet->pt();
+    if (pt<150) continue;
+    double mass         = ijet->mass();
+    double rapidity     = ijet->rapidity();
+    double prunedMass   = ijet->userFloat("ak8CHSJetsCHSPrunedMass");
+    double trimmedMass  = ijet->userFloat("ak8CHSJetsCHSTrimmedMass");
+    double filteredMass = ijet->userFloat("ak8CHSJetsCHSFilteredMass");
+    double softDropMass = ijet->userFloat("ak8CHSJetsCHSSoftDropMass");
+    double ndau         = ijet->numberOfDaughters();
+
+    h_ak8chsmod_pt           ->Fill( pt           );
+    h_ak8chsmod_mass         ->Fill( mass         );
+    h_ak8chsmod_rapidity     ->Fill( rapidity     );
+    h_ak8chsmod_prunedMass   ->Fill( prunedMass   );
+    h_ak8chsmod_trimmedMass  ->Fill( trimmedMass  );
+    h_ak8chsmod_filteredMass ->Fill( filteredMass );
+    h_ak8chsmod_softDropMass ->Fill( softDropMass );
+    h_ak8chsmod_ndau         ->Fill( ndau         );
+  }
+*/
+//   [jdolen@cmslpc24 python]$ edmdump jettoolbox.root 
+// Type                           Module                      Label            Process   
+// --------------------------------------------------------------------------------------
+// edm::ValueMap<float>           "ak12PFJetsCHSFilteredMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak12PFJetsCHSPrunedMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak12PFJetsCHSSoftDropMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak12PFJetsCHSTrimmedMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsCHSFilteredMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsCHSSoftDropMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsCHSTrimmedMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsFilteredMass"     ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsPuppiFilteredMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsPuppiSoftDropMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsPuppiTrimmedMass"   ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsSoftDropMass"     ""               "Ana"     
+// edm::ValueMap<float>           "ak8PFJetsTrimmedMass"      ""               "Ana"     
+// edm::ValueMap<float>           "NjettinessAK12CHS"         "tau1"           "Ana"     
+// edm::ValueMap<float>           "NjettinessAK12CHS"         "tau2"           "Ana"     
+// edm::ValueMap<float>           "NjettinessAK12CHS"         "tau3"           "Ana"     
+// edm::ValueMap<float>           "NjettinessAK12CHS"         "tau4"           "Ana"     
+// vector<pat::Jet>               "selectedPatJetsAK12PFCHS"   ""               "Ana"     
+// vector<pat::Jet>               "selectedPatJetsAK8PF"      ""               "Ana"     
+// vector<pat::Jet>               "selectedPatJetsAK8PFCHS"   ""               "Ana"     
+// vector<pat::Jet>               "selectedPatJetsAK8PFPuppi"   ""               "Ana"     
+// vector<reco::GenJet>           "selectedPatJetsAK12PFCHS"   "genJets"        "Ana"     
+// vector<reco::GenJet>           "selectedPatJetsAK8PF"      "genJets"        "Ana"     
+// vector<reco::GenJet>           "selectedPatJetsAK8PFCHS"   "genJets"        "Ana"     
+// vector<reco::GenJet>           "selectedPatJetsAK8PFPuppi"   "genJets"        "Ana"     
+// vector<reco::PFCandidate>      "selectedPatJetsAK12PFCHS"   "pfCandidates"   "Ana"     
+// vector<reco::PFCandidate>      "selectedPatJetsAK8PF"      "pfCandidates"   "Ana"     
+// vector<reco::PFCandidate>      "selectedPatJetsAK8PFCHS"   "pfCandidates"   "Ana"     
+// vector<reco::PFCandidate>      "selectedPatJetsAK8PFPuppi"   "pfCandidates"   "Ana"  
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+JetTester::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+JetTester::endJob() 
+{
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+JetTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(JetTester);

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -1,4 +1,4 @@
-###############################################
+saveJetCollection###############################################
 ####
 ####   Jet Substructure Toolbox (jetToolBox)
 ####   Python function for easy access of
@@ -52,9 +52,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		addQGTagger=False, QGjetsLabel='chs',
 		addEnergyCorrFunc=False, ecfType = "N", ecfBeta = 1.0, ecfN3 = False,
 		addEnergyCorrFuncSubjets=False, ecfSubjetType = "N", ecfSubjetBeta = 1.0, ecfSubjetN3 = False,
-		# set this to false to disable creation of jettoolbox.root
-		# then you need to associate the jetTask to a Path or EndPath manually in your config
-		associateTask=True,
+		# set this to true to enable creation of edm root file
+		saveJetCollection=False,
 		# 0 = no printouts, 1 = warnings only, 2 = warnings & info, 3 = warnings, info, debug
 		verbosity=2,
 		):
@@ -1071,11 +1070,14 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		getattr( proc, 'jetTask', cms.Task() ).add(*[getattr(proc,prod) for prod in proc.producers_()])
 		getattr( proc, 'jetTask', cms.Task() ).add(*[getattr(proc,filt) for filt in proc.filters_()])
 
-	if associateTask:
-		if hasattr(proc, 'endpath'):
-			getattr( proc, 'endpath').associate( getattr( proc, 'jetTask', cms.Task() ) )
-		else:
-			setattr( proc, 'endpath', cms.EndPath(getattr(proc, outputFile), getattr( proc, 'jetTask', cms.Task() )) )
+	setattr( proc, 'jetPath', cms.Path( getattr( proc, mod["selPATJets"] ) ) )
+	getattr( proc, 'jetPath').associate( getattr( proc, 'jetTask' ) )
+
+	if saveJetCollection:
+	 	if hasattr(proc, 'endpath'):
+	 		getattr( proc, 'endpath').associate( getattr( proc, 'jetTask', cms.Task() ) )
+	 	else:
+	 		setattr( proc, 'endpath', cms.EndPath(getattr(proc, outputFile), getattr( proc, 'jetTask', cms.Task() )) )
 
 	#### removing mc matching for data
 	if runOnData:

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -1,7 +1,7 @@
 ###############################################
 ####
 ####   Jet Substructure Toolbox (jetToolBox)
-####   Python function for easy access of 
+####   Python function for easy access of
 ####   jet substructure tools implemented in CMS
 ####
 ####   Alejandro Gomez Espinosa (alejandro.gomez@cern.ch)
@@ -25,20 +25,20 @@ from collections import OrderedDict
 
 def jetToolbox( proc, jetType, jetSequence, outputFile,
 		updateCollection='', updateCollectionSubjets='',
-		newPFCollection=False, nameNewPFCollection = '',	
-		PUMethod='CHS', 
+		newPFCollection=False, nameNewPFCollection = '',
+		PUMethod='CHS',
 		miniAOD=True,
 		runOnMC=True,
 		JETCorrPayload='', JETCorrLevels = [ 'None' ], GetJetMCFlavour=True,
-		Cut = '', 
+		Cut = '',
 		postFix='',
 		# blank means default list of discriminators, None means none
 		bTagDiscriminators = '',
-		bTagInfos = None, 
+		bTagInfos = None,
 		subjetBTagDiscriminators = '',
-		subjetBTagInfos = None, 
+		subjetBTagInfos = None,
 		subJETCorrPayload='', subJETCorrLevels = [ 'None' ], GetSubjetMCFlavour=True,
-		CutSubjet = '', 
+		CutSubjet = '',
 		addPruning=False, zCut=0.1, rCut=0.5, addPrunedSubjets=False,
 		addSoftDrop=False, betaCut=0.0,  zCutSD=0.1, addSoftDropSubjets=False,
 		addTrimming=False, rFiltTrim=0.2, ptFrac=0.03,
@@ -50,8 +50,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		addNsubSubjets=False, subjetMaxTau=4,
 		addPUJetID=False,
 		addQGTagger=False, QGjetsLabel='chs',
-		addEnergyCorrFunc=False, 
-		addEnergyCorrFuncSubjets=False,
+		addEnergyCorrFunc=False, ecfType = "N", ecfBeta = 1.0, ecfN3 = False,
+		addEnergyCorrFuncSubjets=False, ecfSubjetType = "N", ecfSubjetBeta = 1.0, ecfSubjetN3 = False,
 		# set this to false to disable creation of jettoolbox.root
 		# then you need to associate the jetTask to a Path or EndPath manually in your config
 		associateTask=True,
@@ -63,7 +63,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	if runOnData:
 		GetJetMCFlavour = False
 		GetSubjetMCFlavour = False
-	
+
 	###############################################################################
 	#######  Verifying some inputs and defining variables
 	###############################################################################
@@ -73,8 +73,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	recommendedJetAlgos = [ 'ak4', 'ak8', 'ca4', 'ca8', 'ca10', 'ca15' ]
 	payloadList = [ 'None',
 			'AK1PFchs', 'AK2PFchs', 'AK3PFchs', 'AK4PFchs', 'AK5PFchs', 'AK6PFchs', 'AK7PFchs', 'AK8PFchs', 'AK9PFchs', 'AK10PFchs',
-			'AK1PFPuppi', 'AK2PFPuppi', 'AK3PFPuppi', 'AK4PFPuppi', 'AK5PFPuppi', 'AK6PFPuppi', 'AK7PFPuppi', 'AK8PFPuppi', 'AK9PFPuppi', 'AK10PFPuppi',  
-			'AK1PFSK', 'AK2PFSK', 'AK3PFSK', 'AK4PFSK', 'AK5PFSK', 'AK6PFSK', 'AK7PFSK', 'AK8PFSK', 'AK9PFSK', 'AK10PFSK',  
+			'AK1PFPuppi', 'AK2PFPuppi', 'AK3PFPuppi', 'AK4PFPuppi', 'AK5PFPuppi', 'AK6PFPuppi', 'AK7PFPuppi', 'AK8PFPuppi', 'AK9PFPuppi', 'AK10PFPuppi',
+			'AK1PFSK', 'AK2PFSK', 'AK3PFSK', 'AK4PFSK', 'AK5PFSK', 'AK6PFSK', 'AK7PFSK', 'AK8PFSK', 'AK9PFSK', 'AK10PFSK',
 			'AK1PF', 'AK2PF', 'AK3PF', 'AK4PF', 'AK5PF', 'AK6PF', 'AK7PF', 'AK8PF', 'AK9PF', 'AK10PF' ]
 	JECLevels = [ 'L1Offset', 'L1FastJet', 'L1JPTOffset', 'L2Relative', 'L3Absolute', 'L5Falvour', 'L7Parton' ]
 	if runOnData:
@@ -82,7 +82,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	jetAlgo = ''
 	algorithm = ''
 	size = ''
-	for TYPE, tmpAlgo in supportedJetAlgos.iteritems(): 
+	for TYPE, tmpAlgo in supportedJetAlgos.iteritems():
 		if TYPE in jetType.lower():
 			jetAlgo = TYPE
 			algorithm = tmpAlgo
@@ -98,7 +98,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 
 	#################################################################################
-	####### Toolbox start 
+	####### Toolbox start
 	#################################################################################
 
 	elemToKeep = []
@@ -110,11 +110,11 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	mod = OrderedDict()
 
 	### List of Jet Corrections
-	if not set(JETCorrLevels).issubset(set(JECLevels)): 
+	if not set(JETCorrLevels).issubset(set(JECLevels)):
 		if ( 'CHS' in PUMethod ) or  ( 'Plain' in PUMethod ): JETCorrLevels = ['L1FastJet','L2Relative', 'L3Absolute']
 		else: JETCorrLevels = [ 'L2Relative', 'L3Absolute']
 		if runOnData: JETCorrLevels.append('L2L3Residual')
-	if not set(subJETCorrLevels).issubset(set(JECLevels)): 
+	if not set(subJETCorrLevels).issubset(set(JECLevels)):
 		if ( 'CHS' in PUMethod ) or  ( 'Plain' in PUMethod ): subJETCorrLevels = ['L1FastJet','L2Relative', 'L3Absolute']
 		else: subJETCorrLevels = [ 'L2Relative', 'L3Absolute']
 		if runOnData: subJETCorrLevels.append('L2L3Residual')
@@ -140,7 +140,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	mod["PATJetsLabelPost"] = mod["PATJetsLabel"]+postFix
 	# some substructure quantities don't include the 'PF' in the name
 	mod["SubstructureLabel"] = jetALGO+PUMethod+postFix
-	if not updateCollection: 
+	if not updateCollection:
 
 		mod["GenJetsNoNu"] = jetalgo+'GenJetsNoNu'
 		#### For MiniAOD
@@ -160,16 +160,16 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				## Filter out neutrinos from packed GenParticles
 				mod["GenParticlesNoNu"] = 'packedGenParticlesForJetsNoNu'
 				setattr( proc, mod["GenParticlesNoNu"],
-						cms.EDFilter("CandPtrSelector", 
-							src = cms.InputTag("packedGenParticles"), 
+						cms.EDFilter("CandPtrSelector",
+							src = cms.InputTag("packedGenParticles"),
 							cut = cms.string("abs(pdgId) != 12 && abs(pdgId) != 14 && abs(pdgId) != 16")
 							))
 				jetSeq += getattr(proc, mod["GenParticlesNoNu"])
 
-				setattr( proc, mod["GenJetsNoNu"], 
+				setattr( proc, mod["GenJetsNoNu"],
 						ak4GenJets.clone( src = mod["GenParticlesNoNu"],
-							rParam = jetSize, 
-							jetAlgorithm = algorithm ) ) 
+							rParam = jetSize,
+							jetAlgorithm = algorithm ) )
 				jetSeq += getattr(proc, mod["GenJetsNoNu"])
 
 			#for Inclusive Vertex Finder
@@ -189,20 +189,20 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 			if runOnMC:
 				proc.load('RecoJets.Configuration.GenJetParticles_cff')
-				setattr( proc, mod["GenJetsNoNu"], ak4GenJets.clone( src = 'genParticlesForJetsNoNu', rParam = jetSize, jetAlgorithm = algorithm ) ) 
+				setattr( proc, mod["GenJetsNoNu"], ak4GenJets.clone( src = 'genParticlesForJetsNoNu', rParam = jetSize, jetAlgorithm = algorithm ) )
 				jetSeq += getattr(proc, mod["GenJetsNoNu"])
-			
+
 
 		####  Creating PATjets
 		tmpPfCandName = pfCand.lower()
 		mod["PFJets"] = ""
 		if 'Puppi' in PUMethod:
-			if ('puppi' in tmpPfCandName): 
+			if ('puppi' in tmpPfCandName):
 				srcForPFJets = pfCand
 				if verbosity>=1: print('|---- jetToolBox: Not running puppi algorithm because keyword puppi was specified in nameNewPFCollection, but applying puppi corrections.')
-			else: 
+			else:
 				proc.load('CommonTools.PileupAlgos.Puppi_cff')
-				puppi.candName = cms.InputTag( pfCand ) 
+				puppi.candName = cms.InputTag( pfCand )
 				if miniAOD:
 				  puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
 				  puppi.clonePackedCands = cms.bool(True)
@@ -211,11 +211,11 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 			from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJetsPuppi
 			mod["PFJets"] = jetalgo+'PFJetsPuppi'+postFix
-			setattr( proc, mod["PFJets"], 
+			setattr( proc, mod["PFJets"],
 					ak4PFJetsPuppi.clone( src = cms.InputTag( srcForPFJets ),
-						doAreaFastjet = True, 
-						rParam = jetSize, 
-						jetAlgorithm = algorithm ) )  
+						doAreaFastjet = True,
+						rParam = jetSize,
+						jetAlgorithm = algorithm ) )
 			jetSeq += getattr(proc, mod["PFJets"])
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFPuppi'
@@ -223,48 +223,48 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		elif 'SK' in PUMethod:
 
-			if ('sk' in tmpPfCandName): 
+			if ('sk' in tmpPfCandName):
 				srcForPFJets = pfCand
 				if verbosity>=1: print('|---- jetToolBox: Not running softkiller algorithm because keyword SK was specified in nameNewPFCollection, but applying SK corrections.')
 			else:
 				proc.load('CommonTools.PileupAlgos.softKiller_cfi')
-				getattr( proc, 'softKiller' ).PFCandidates = cms.InputTag( pfCand ) 
+				getattr( proc, 'softKiller' ).PFCandidates = cms.InputTag( pfCand )
 				jetSeq += getattr(proc, 'softKiller' )
 				srcForPFJets = 'softKiller'
 
 			from RecoJets.JetProducers.ak4PFJetsSK_cfi import ak4PFJetsSK
 			mod["PFJets"] = jetalgo+'PFJetsSK'+postFix
-			setattr( proc, mod["PFJets"], 
+			setattr( proc, mod["PFJets"],
 					ak4PFJetsSK.clone(  src = cms.InputTag( srcForPFJets ),
-						rParam = jetSize, 
-						jetAlgorithm = algorithm ) ) 
+						rParam = jetSize,
+						jetAlgorithm = algorithm ) )
 			jetSeq += getattr(proc, mod["PFJets"])
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFSK'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFSK'
-		
-		elif 'CS' in PUMethod: 
+
+		elif 'CS' in PUMethod:
 
 			from RecoJets.JetProducers.ak4PFJetsCHSCS_cfi import ak4PFJetsCHSCS
 			mod["PFJets"] = jetalgo+'PFJetsCS'+postFix
-			setattr( proc, mod["PFJets"], 
-					ak4PFJetsCHSCS.clone( doAreaFastjet = True, 
+			setattr( proc, mod["PFJets"],
+					ak4PFJetsCHSCS.clone( doAreaFastjet = True,
 						src = cms.InputTag( pfCand ), #srcForPFJets ),
 						csRParam = cms.double(jetSize),
-						jetAlgorithm = algorithm ) ) 
+						jetAlgorithm = algorithm ) )
 			if miniAOD: getattr( proc, mod["PFJets"]).src = pfCand
 			jetSeq += getattr(proc, mod["PFJets"])
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFCS'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFCS'
 
-		elif 'CHS' in PUMethod: 
-			
+		elif 'CHS' in PUMethod:
+
 			if miniAOD:
-				if ('chs' in tmpPfCandName): 
+				if ('chs' in tmpPfCandName):
 					srcForPFJets = pfCand
 					if verbosity>=1: print('|---- jetToolBox: Not running CHS algorithm because keyword CHS was specified in nameNewPFCollection, but applying CHS corrections.')
-				else: 
+				else:
 					setattr( proc, 'chs', cms.EDFilter('CandPtrSelector', src = cms.InputTag( pfCand ), cut = cms.string('fromPV')) )
 					jetSeq += getattr(proc, 'chs')
 					srcForPFJets = 'chs'
@@ -280,29 +280,29 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					setattr( proc, 'newPfNoPileUpJME', pfNoPileUpJME.clone( topCollection='newPfPileUpJME', bottomCollection= 'newParticleFlowTmpPtrs' ) )
 					jetSeq += getattr(proc, 'newPfNoPileUpJME')
 					srcForPFJets = 'newPfNoPileUpJME'
-				else: 
+				else:
 					proc.load('CommonTools.ParticleFlow.pfNoPileUpJME_cff')
 					srcForPFJets = 'pfNoPileUpJME'
-				
+
 			mod["PFJets"] = jetalgo+'PFJetsCHS'+postFix
-			setattr( proc, mod["PFJets"], 
-					ak4PFJetsCHS.clone( src = cms.InputTag( srcForPFJets ), 
-						doAreaFastjet = True, 
-						rParam = jetSize, 
-						jetAlgorithm = algorithm ) ) 
+			setattr( proc, mod["PFJets"],
+					ak4PFJetsCHS.clone( src = cms.InputTag( srcForPFJets ),
+						doAreaFastjet = True,
+						rParam = jetSize,
+						jetAlgorithm = algorithm ) )
 			jetSeq += getattr(proc, mod["PFJets"])
 
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PFchs'
 			if subJETCorrPayload not in payloadList: subJETCorrPayload = 'AK4PFchs'
 
-		else: 
+		else:
 			PUMethod = ''
 			mod["PFJets"] = jetalgo+'PFJets'+postFix
-			setattr( proc, mod["PFJets"], 
-					ak4PFJets.clone( 
-						doAreaFastjet = True, 
-						rParam = jetSize, 
-						jetAlgorithm = algorithm ) ) 
+			setattr( proc, mod["PFJets"],
+					ak4PFJets.clone(
+						doAreaFastjet = True,
+						rParam = jetSize,
+						jetAlgorithm = algorithm ) )
 			if miniAOD: getattr( proc, mod["PFJets"]).src = pfCand
 			jetSeq += getattr(proc, mod["PFJets"])
 			if JETCorrPayload not in payloadList: JETCorrPayload = 'AK'+size+'PF'
@@ -311,7 +311,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 		if 'None' in JETCorrPayload: JEC = None
 		else: JEC = ( JETCorrPayload.replace('CS','chs').replace('SK','chs') , JETCorrLevels, 'None' )   ### temporary
-		#else: JEC = ( JETCorrPayload., JETCorrLevels, 'None' ) 
+		#else: JEC = ( JETCorrPayload., JETCorrLevels, 'None' )
 		if verbosity>=2: print('|---- jetToolBox: Applying these corrections: '+str(JEC))
 
 		if addPrunedSubjets or addSoftDropSubjets or addCMSTopTagger:
@@ -330,14 +330,14 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				proc,
 				labelName = mod["PATJetsLabel"],
 				jetSource = cms.InputTag(mod["PFJets"]),
-				postfix = postFix, 
+				postfix = postFix,
 				algo = jetalgo,
 				rParam = jetSize,
-				jetCorrections = JEC if JEC is not None else None, 
-				pfCandidates = cms.InputTag( pfCand ),  
-				svSource = cms.InputTag( svLabel ),  
+				jetCorrections = JEC if JEC is not None else None,
+				pfCandidates = cms.InputTag( pfCand ),
+				svSource = cms.InputTag( svLabel ),
 				genJetCollection = cms.InputTag(mod["GenJetsNoNu"]),
-				pvSource = cms.InputTag( pvLabel ), 
+				pvSource = cms.InputTag( pvLabel ),
 				muSource = cms.InputTag( muLabel ),
 				elSource = cms.InputTag( elLabel ),
 				btagDiscriminators = bTagDiscriminators,
@@ -363,7 +363,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		muLabel = 'slimmedMuons'
 		elLabel = 'slimmedElectrons'
 
-		if not JETCorrPayload: 
+		if not JETCorrPayload:
 			raise ValueError('|---- jetToolBox: updateCollection option requires to add JETCorrPayload.')
 
 		JEC = ( JETCorrPayload, JETCorrLevels, 'None' )   ### temporary
@@ -373,7 +373,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 				postfix = postFix,
 				jetSource = cms.InputTag( updateCollection ),
 				labelName = mod["PATJetsLabel"],
-				jetCorrections = JEC, 
+				jetCorrections = JEC,
 				btagDiscriminators = bTagDiscriminators,
 				)
 		mod["PATJetsCorrFactors"] = 'patJetCorrFactors'+mod["PATJetsLabelPost"]
@@ -394,10 +394,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					proc,
 					jetSource = cms.InputTag( updateCollectionSubjets ),
 					labelName = mod["PATSubjetsLabel"],
-					jetCorrections = JEC, 
+					jetCorrections = JEC,
 					explicitJTA = True,
 					fatJets = cms.InputTag( updateCollection ),
-					rParam = jetSize, 
+					rParam = jetSize,
 					algo = jetALGO,
 					btagDiscriminators = subjetBTagDiscriminators,
 					)
@@ -406,7 +406,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			getattr( proc, mod["PATSubjetsCorrFactors"] ).levels = subJETCorrLevels
 			patSubJets = 'updatedPatJets'+mod["PATSubjetsLabel"]
 
-		if addPrunedSubjets or addSoftDropSubjets or addCMSTopTagger or addMassDrop or addHEPTopTagger or addPruning or addSoftDrop: 
+		if addPrunedSubjets or addSoftDropSubjets or addCMSTopTagger or addMassDrop or addHEPTopTagger or addPruning or addSoftDrop:
 			if verbosity>=1: print('|---- jetToolBox: You are trying to add a groomer variable into a clustered jet collection. THIS IS NOT RECOMMENDED, it is recommended to recluster jets instead using a plain jetToolbox configuration. Please use this feature at your own risk.')
 
 	mod["PFJetsOrUpdate"] = mod["PFJets"] if not updateCollection else updateCollection
@@ -416,28 +416,28 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		print('|---- jetToolBox: Adding these btag discriminators: '+str(subjetBTagDiscriminators)+' in the subjet collection.')
 
 	#### Groomers
-	if addSoftDrop or addSoftDropSubjets: 
+	if addSoftDrop or addSoftDropSubjets:
 
 		mod["PFJetsSoftDrop"] = mod["PFJets"]+'SoftDrop'
 		mod["SoftDropMass"] = mod["PFJets"]+'SoftDropMass'
 		setattr( proc, mod["PFJetsSoftDrop"],
-			ak8PFJetsCHSSoftDrop.clone( 
+			ak8PFJetsCHSSoftDrop.clone(
 				src = cms.InputTag( mod["PFJetsConstituentsColonOrUpdate"] ),
-				rParam = jetSize, 
-				jetAlgorithm = algorithm, 
+				rParam = jetSize,
+				jetAlgorithm = algorithm,
 				useExplicitGhosts=True,
 				R0= cms.double(jetSize),
-				zcut=zCutSD, 
+				zcut=zCutSD,
 				beta=betaCut,
 				doAreaFastjet = cms.bool(True),
 				writeCompound = cms.bool(True),
 				jetCollInstanceName=cms.string('SubJets') ) )
 		setattr( proc, mod["SoftDropMass"],
-			ak8PFJetsCHSSoftDropMass.clone( src = cms.InputTag( mod["PFJetsOrUpdate"] ), 
+			ak8PFJetsCHSSoftDropMass.clone( src = cms.InputTag( mod["PFJetsOrUpdate"] ),
 				matched = cms.InputTag( mod["PFJetsSoftDrop"] ),
 				distMax = cms.double( jetSize ) ) )
 
-		elemToKeep += [ 'keep *_'+mod["SoftDropMass"]+'_*_*'] 
+		elemToKeep += [ 'keep *_'+mod["SoftDropMass"]+'_*_*']
 		jetSeq += getattr(proc, mod["PFJetsSoftDrop"] )
 		jetSeq += getattr(proc, mod["SoftDropMass"] )
 		getattr( proc, mod["PATJets"]).userData.userFloats.src += [ mod["SoftDropMass"] ]
@@ -451,10 +451,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 						ak4GenJets.clone(
 							SubJetParameters,
 							useSoftDrop = cms.bool(True),
-							rParam = jetSize, 
-							jetAlgorithm = algorithm, 
+							rParam = jetSize,
+							jetAlgorithm = algorithm,
 							useExplicitGhosts=cms.bool(True),
-							#zcut=cms.double(zCutSD), 
+							#zcut=cms.double(zCutSD),
 							R0= cms.double(jetSize),
 							beta=cms.double(betaCut),
 							writeCompound = cms.bool(True),
@@ -470,7 +470,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					jetSource = cms.InputTag( mod["PFJetsSoftDrop"]),
 					algo = jetalgo,
 					rParam = jetSize,
-					jetCorrections = JEC if JEC is not None else None, 
+					jetCorrections = JEC if JEC is not None else None,
 					pvSource = cms.InputTag( pvLabel ),
 					btagDiscriminators = ['None'],
 					genJetCollection = cms.InputTag( mod["GenJetsNoNu"]),
@@ -490,10 +490,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					jetSource = cms.InputTag( mod["PFJetsSoftDrop"], 'SubJets'),
 					algo = jetalgo,  # needed for subjet b tagging
 					rParam = jetSize,  # needed for subjet b tagging
-					jetCorrections = subJEC if subJEC is not None else None, 
-					pfCandidates = cms.InputTag( pfCand ), 
-					pvSource = cms.InputTag( pvLabel), 
-					svSource = cms.InputTag( svLabel ),  
+					jetCorrections = subJEC if subJEC is not None else None,
+					pfCandidates = cms.InputTag( pfCand ),
+					pvSource = cms.InputTag( pvLabel),
+					svSource = cms.InputTag( svLabel ),
 					muSource = cms.InputTag( muLabel ),
 					elSource = cms.InputTag( elLabel ),
 					btagDiscriminators = subjetBTagDiscriminators,
@@ -506,7 +506,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					fatJets=cms.InputTag(mod["PFJets"]),             # needed for subjet flavor clustering
 					groomedFatJets=cms.InputTag(mod["PFJetsSoftDrop"]), # needed for subjet flavor clustering
 					outputModules = ['outputFile']
-					) 
+					)
 			mod["PATSubjetsSoftDrop"] = patJets+mod["PATSubjetsSoftDropLabel"]
 			mod["selPATSubjetsSoftDrop"] = selPatJets+mod["PATSubjetsSoftDropLabel"]
 
@@ -532,7 +532,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 						fixDaughters = cms.bool(False),
 						algoTags = cms.VInputTag(
 						cms.InputTag(mod["selPATJetsSoftDropPacked"])
-						), 
+						),
 						algoLabels =cms.vstring('SoftDrop')
 						)
 				 )
@@ -542,30 +542,30 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 
 
-	if addPruning or addPrunedSubjets: 
+	if addPruning or addPrunedSubjets:
 
 		mod["PFJetsPruned"] = mod["PFJets"]+'Pruned'
 		mod["PrunedMass"] =  mod["PFJets"]+'PrunedMass'
 		setattr( proc, mod["PFJetsPruned"],
-			ak8PFJetsCHSPruned.clone( 
+			ak8PFJetsCHSPruned.clone(
 				src = cms.InputTag( mod["PFJetsConstituentsColonOrUpdate"] ),
-				rParam = jetSize, 
-				jetAlgorithm = algorithm, 
-				zcut=zCut, 
+				rParam = jetSize,
+				jetAlgorithm = algorithm,
+				zcut=zCut,
 				rcut_factor=rCut,
 				writeCompound = cms.bool(True),
 				doAreaFastjet = cms.bool(True),
 				jetCollInstanceName=cms.string('SubJets') ) )
 		setattr( proc, mod["PrunedMass"],
-			ak8PFJetsCHSPrunedMass.clone( 
-				src = cms.InputTag( mod["PFJetsOrUpdate"] ), 
-				matched = cms.InputTag( mod["PFJetsPruned"]), 
+			ak8PFJetsCHSPrunedMass.clone(
+				src = cms.InputTag( mod["PFJetsOrUpdate"] ),
+				matched = cms.InputTag( mod["PFJetsPruned"]),
 				distMax = cms.double( jetSize ) ) )
 
 		jetSeq += getattr(proc, mod["PFJetsPruned"])
 		jetSeq += getattr(proc, mod["PrunedMass"])
 		getattr( proc, mod["PATJets"]).userData.userFloats.src += [ mod["PrunedMass"] ]
-		elemToKeep += [ 'keep *_'+mod["PrunedMass"]+'_*_*'] 
+		elemToKeep += [ 'keep *_'+mod["PrunedMass"]+'_*_*']
 		toolsUsed.append( mod["PrunedMass"] )
 
 		if addPrunedSubjets:
@@ -589,7 +589,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					jetSource = cms.InputTag( mod["PFJetsPruned"]),
 					algo = jetalgo,
 					rParam = jetSize,
-					jetCorrections = JEC if JEC is not None else None, 
+					jetCorrections = JEC if JEC is not None else None,
 					pvSource = cms.InputTag( pvLabel ),
 					btagDiscriminators = ['None'],
 					genJetCollection = cms.InputTag( mod["GenJetsNoNu"]),
@@ -609,10 +609,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					jetSource = cms.InputTag( mod["PFJetsPruned"], 'SubJets'),
 					algo = jetalgo,  # needed for subjet b tagging
 					rParam = jetSize,  # needed for subjet b tagging
-					jetCorrections = subJEC if subJEC is not None else None, 
-					pfCandidates = cms.InputTag( pfCand ),  
-					pvSource = cms.InputTag( pvLabel), 
-					svSource = cms.InputTag( svLabel ), 
+					jetCorrections = subJEC if subJEC is not None else None,
+					pfCandidates = cms.InputTag( pfCand ),
+					pvSource = cms.InputTag( pvLabel),
+					svSource = cms.InputTag( svLabel ),
 					muSource = cms.InputTag( muLabel ),
 					elSource = cms.InputTag( elLabel ),
 					getJetMCFlavour = GetSubjetMCFlavour,
@@ -625,7 +625,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					fatJets=cms.InputTag(mod["PFJets"]),             # needed for subjet flavor clustering
 					groomedFatJets=cms.InputTag(mod["PFJetsPruned"]), # needed for subjet flavor clustering
 					outputModules = ['outputFile']
-					) 
+					)
 			mod["PATSubjetsPruned"] = patJets+mod["PATSubjetsPrunedLabel"]
 			mod["selPATSubjetsPruned"] = selPatJets+mod["PATSubjetsPrunedLabel"]
 
@@ -651,7 +651,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 						fixDaughters = cms.bool(False),
 						algoTags = cms.VInputTag(
 						cms.InputTag(mod["selPATJetsPrunedPacked"])
-						), 
+						),
 						algoLabels =cms.vstring('Pruned')
 						)
 				 )
@@ -665,19 +665,19 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		mod["PFJetsTrimmed"] = mod["PFJets"]+'Trimmed'
 		mod["TrimmedMass"] = mod["PFJets"]+'TrimmedMass'
 		setattr( proc, mod["PFJetsTrimmed"],
-				ak8PFJetsCHSTrimmed.clone( 
-					rParam = jetSize, 
+				ak8PFJetsCHSTrimmed.clone(
+					rParam = jetSize,
 					src = cms.InputTag( mod["PFJetsConstituentsColonOrUpdate"] ),
 					jetAlgorithm = algorithm,
 					rFilt= rFiltTrim,
-					trimPtFracMin= ptFrac) ) 
-		setattr( proc, mod["TrimmedMass"], 
-				ak8PFJetsCHSTrimmedMass.clone( 
-					src = cms.InputTag( mod["PFJetsOrUpdate"] ), 
-					matched = cms.InputTag( mod["PFJetsTrimmed"]), 
+					trimPtFracMin= ptFrac) )
+		setattr( proc, mod["TrimmedMass"],
+				ak8PFJetsCHSTrimmedMass.clone(
+					src = cms.InputTag( mod["PFJetsOrUpdate"] ),
+					matched = cms.InputTag( mod["PFJetsTrimmed"]),
 					distMax = cms.double( jetSize ) ) )
 
-		elemToKeep += [ 'keep *_'+mod["TrimmedMass"]+'_*_*'] 
+		elemToKeep += [ 'keep *_'+mod["TrimmedMass"]+'_*_*']
 		jetSeq += getattr(proc, mod["PFJetsTrimmed"])
 		jetSeq += getattr(proc, mod["TrimmedMass"])
 		getattr( proc, mod["PATJets"]).userData.userFloats.src += [mod["TrimmedMass"]]
@@ -688,18 +688,18 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		mod["PFJetsFiltered"] = mod["PFJets"]+'Filtered'
 		mod["FilteredMass"] = mod["PFJets"]+'FilteredMass'
 		setattr( proc, mod["PFJetsFiltered"],
-				ak8PFJetsCHSFiltered.clone( 
+				ak8PFJetsCHSFiltered.clone(
 					src = cms.InputTag( mod["PFJetsConstituentsColonOrUpdate"] ),
-					rParam = jetSize, 
+					rParam = jetSize,
 					jetAlgorithm = algorithm,
 					rFilt= rfilt,
-					nFilt= nfilt ) ) 
+					nFilt= nfilt ) )
 		setattr( proc, mod["FilteredMass"],
-				ak8PFJetsCHSFilteredMass.clone( 
-					src = cms.InputTag( mod["PFJetsOrUpdate"] ), 
-					matched = cms.InputTag( mod["PFJetsFiltered"]), 
+				ak8PFJetsCHSFilteredMass.clone(
+					src = cms.InputTag( mod["PFJetsOrUpdate"] ),
+					matched = cms.InputTag( mod["PFJetsFiltered"]),
 					distMax = cms.double( jetSize ) ) )
-		elemToKeep += [ 'keep *_'+mod["FilteredMass"]+'_*_*'] 
+		elemToKeep += [ 'keep *_'+mod["FilteredMass"]+'_*_*']
 		jetSeq += getattr(proc, mod["PFJetsFiltered"])
 		jetSeq += getattr(proc, mod["FilteredMass"])
 		getattr( proc, patJets+jetALGO+'PF'+PUMethod+postFix).userData.userFloats.src += [mod["FilteredMass"]]
@@ -707,12 +707,12 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 	if addCMSTopTagger :
 
-		if 'CA' in jetALGO : 
+		if 'CA' in jetALGO :
 
 			mod["PFJetsCMSTopTag"] = mod["PFJets"].replace(jetalgo,"cmsTopTag")
 			setattr( proc, mod["PFJetsCMSTopTag"],
 					cms.EDProducer("CATopJetProducer",
-						PFJetParameters.clone( 
+						PFJetParameters.clone(
 							src = cms.InputTag( mod["PFJetsConstituentsColonOrUpdate"] ),
 							doAreaFastjet = cms.bool(True),
 							doRhoFastjet = cms.bool(False),
@@ -736,7 +736,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 						writeCompound = cms.bool(True)
 						)
 					)
-			
+
 			mod["CATopTagInfos"] = "CATopTagInfos"+postFix
 			setattr( proc, mod["CATopTagInfos"],
 					cms.EDProducer("CATopJetTagger",
@@ -757,10 +757,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					proc,
 					labelName = mod["PATJetsCMSTopTagLabel"],
 					jetSource = cms.InputTag(mod["PFJetsCMSTopTag"]),
-					jetCorrections = JEC if JEC is not None else None, 
-					pfCandidates = cms.InputTag( pfCand ),  
-					pvSource = cms.InputTag( pvLabel), 
-					svSource = cms.InputTag( svLabel ), 
+					jetCorrections = JEC if JEC is not None else None,
+					pfCandidates = cms.InputTag( pfCand ),
+					pvSource = cms.InputTag( pvLabel),
+					svSource = cms.InputTag( svLabel ),
 					muSource = cms.InputTag( muLabel ),
 					elSource = cms.InputTag( elLabel ),
 					btagDiscriminators = bTagDiscriminators,
@@ -782,10 +782,10 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					jetSource = cms.InputTag(mod["PFJetsCMSTopTag"], 'SubJets'),
 					algo = jetalgo,  # needed for subjet b tagging
 					rParam = jetSize,  # needed for subjet b tagging
-					jetCorrections = subJEC if subJEC is not None else None, 
-					pfCandidates = cms.InputTag( pfCand ),  
-					pvSource = cms.InputTag( pvLabel), 
-					svSource = cms.InputTag( svLabel ), 
+					jetCorrections = subJEC if subJEC is not None else None,
+					pfCandidates = cms.InputTag( pfCand ),
+					pvSource = cms.InputTag( pvLabel),
+					svSource = cms.InputTag( svLabel ),
 					muSource = cms.InputTag( muLabel ),
 					elSource = cms.InputTag( elLabel ),
 					btagDiscriminators = bTagDiscriminators,
@@ -822,7 +822,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			mod["PFJetsMassDrop"] = mod["PFJets"]+'MassDropFiltered'
 			mod["MassDropFilteredMass"] = mod["PFJetsMassDrop"]+'Mass'
 			setattr( proc, mod["PFJetsMassDrop"],
-					ca15PFJetsCHSMassDropFiltered.clone( 
+					ca15PFJetsCHSMassDropFiltered.clone(
 						rParam = jetSize,
 						src = cms.InputTag( mod["PFJetsConstituentsColonOrUpdate"] ),
 						) )
@@ -836,13 +836,13 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		else:
 			raise ValueError('|---- jetToolBox: CMS recommends CambridgeAachen for Mass Drop, you are using '+algorithm+'. JetToolbox will not run Mass Drop.')
 
-	if addHEPTopTagger: 
-		if ( jetSize >= 1. ) and ( 'CA' in jetALGO ): 
+	if addHEPTopTagger:
+		if ( jetSize >= 1. ) and ( 'CA' in jetALGO ):
 
 			mod["PFJetsHEPTopTag"] = mod["PFJets"].replace(jetalgo,"hepTopTag")
 			mod["PFJetsHEPTopTagMass"] = mod["PFJetsHEPTopTag"]+'Mass'+jetALGO
 			setattr( proc, mod["PFJetsHEPTopTag"], hepTopTagPFJetsCHS.clone( src = cms.InputTag( mod["PFJetsConstituentsColonOrUpdate"] ) ) )
-			setattr( proc, mod["PFJetsHEPTopTagMass"], ak8PFJetsCHSPrunedMass.clone( src = cms.InputTag(mod["PFJets"]), 
+			setattr( proc, mod["PFJetsHEPTopTagMass"], ak8PFJetsCHSPrunedMass.clone( src = cms.InputTag(mod["PFJets"]),
 				matched = cms.InputTag(mod["PFJetsHEPTopTag"]), distMax = cms.double( jetSize ) ) )
 			elemToKeep += [ 'keep *_'+mod["PFJetsHEPTopTagMass"]+'_*_*' ]
 			getattr( proc, mod["PATJets"]).userData.userFloats.src += [ mod["PFJetsHEPTopTagMass"] ]
@@ -861,7 +861,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		setattr( proc, mod["Njettiness"],
 				Njettiness.clone( src = cms.InputTag( mod["PFJetsOrUpdate"] ),
 					Njets=cms.vuint32(rangeTau),         # compute 1-, 2-, 3-, 4- subjettiness
-					# variables for measure definition : 
+					# variables for measure definition :
 					measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
 					beta = cms.double(1.0),              # CMS default is 1
 					R0 = cms.double( jetSize ),              # CMS default is jet cone size
@@ -872,7 +872,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					akAxesR0 = cms.double(-999.0) ) )        # not used by default
 
 		elemToKeep += [ 'keep *_'+mod["Njettiness"]+'_*_*' ]
-		for tau in rangeTau: getattr( proc, mod["PATJets"]).userData.userFloats.src += [mod["Njettiness"]+':tau'+str(tau) ] 
+		for tau in rangeTau: getattr( proc, mod["PATJets"]).userData.userFloats.src += [mod["Njettiness"]+':tau'+str(tau) ]
 		jetSeq += getattr(proc, mod["Njettiness"])
 		toolsUsed.append( mod["Njettiness"] )
 
@@ -894,15 +894,15 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 			mod["NsubGroomer"] = mod["PFJetsPruned"]
 			mod["NsubSubjets"] = mod["PATSubjetsPrunedLabel"]
 			mod["NsubPATSubjets"] = mod["PATSubjetsPruned"]
-		else: 
+		else:
 			raise ValueError('|---- jetToolBox: Nsubjettiness of subjets needs a Subjet collection. Or create one using addSoftDropSubjets option, or updateCollection.')
 
 		mod["Nsubjettiness"] = 'Nsubjettiness'+mod["NsubSubjets"]
 		rangeTau = range(1,subjetMaxTau+1)
 		setattr( proc, mod["Nsubjettiness"],
-				Njettiness.clone( src = cms.InputTag( ( mod["NsubGroomer"] if not updateCollectionSubjets else updateCollectionSubjets ), 'SubJets' ), 
+				Njettiness.clone( src = cms.InputTag( ( mod["NsubGroomer"] if not updateCollectionSubjets else updateCollectionSubjets ), 'SubJets' ),
 					Njets=cms.vuint32(rangeTau),         # compute 1-, 2-, 3-, 4- subjettiness
-					# variables for measure definition : 
+					# variables for measure definition :
 					measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
 					beta = cms.double(1.0),              # CMS default is 1
 					R0 = cms.double( jetSize ),              # CMS default is jet cone size
@@ -913,7 +913,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					akAxesR0 = cms.double(-999.0) ) )        # not used by default
 
 		elemToKeep += [ 'keep *_'+mod["Nsubjettiness"]+'_*_*' ]
-		for tau in rangeTau: getattr( proc, ( mod["NsubPATSubjets"] if not updateCollectionSubjets else patSubJets ) ).userData.userFloats.src += [mod["Nsubjettiness"]+':tau'+str(tau) ] 
+		for tau in rangeTau: getattr( proc, ( mod["NsubPATSubjets"] if not updateCollectionSubjets else patSubJets ) ).userData.userFloats.src += [mod["Nsubjettiness"]+':tau'+str(tau) ]
 		jetSeq += getattr(proc, mod["Nsubjettiness"])
 		toolsUsed.append( mod["Nsubjettiness"] )
 
@@ -937,7 +937,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		else:
 			raise ValueError('|---- jetToolBox: QGTagger is optimized for ak4 jets with CHS. NOT running QGTagger')
 
-			
+
 	####### Pileup JetID
 	if addPUJetID:
 		if ( 'ak4' in jetalgo ) and ( PUMethod not in ['CS','SK'] ):
@@ -975,72 +975,66 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	if addEnergyCorrFunc:
 		if PUMethod!="Puppi" or (addSoftDrop==False and addSoftDropSubjets==False):
 			raise ValueError("|---- jetToolBox: addEnergyCorrFunc only supported for Puppi w/ addSoftDrop or addSoftDropSubjets")
-		from RecoJets.JetProducers.ECF_cff import ecfNbeta1, ecfNbeta2
-		mod["ECFnb1"] = 'nb1'+mod["SubstructureLabel"]+'SoftDrop'
-		mod["ECFnb2"] = 'nb2'+mod["SubstructureLabel"]+'SoftDrop'
-		setattr(proc, mod["ECFnb1"], ecfNbeta1.clone(src = cms.InputTag(mod["PFJetsSoftDrop"]), cuts = cms.vstring('', '', 'pt > 250')))
-		setattr(proc, mod["ECFnb2"], ecfNbeta2.clone(src = cms.InputTag(mod["PFJetsSoftDrop"]), cuts = cms.vstring('', '', 'pt > 250')))
-		elemToKeep += [ 'keep *_'+mod["ECFnb1"]+'_*_*', 'keep *_'+mod["ECFnb2"]+'_*_*']
-		jetSeq += getattr(proc, mod["ECFnb1"])
-		jetSeq += getattr(proc, mod["ECFnb2"])
-		toolsUsed.extend([mod["ECFnb1"], mod["ECFnb2"]])
+		from RecoJets.JetProducers.ECF_cff import ecf
+		ecfVar = ecfType.lower()+"b"+str(int(ecfBeta))
+		mod["ECF"+ecfVar] = ecfVar+mod["SubstructureLabel"]+'SoftDrop'
+		setattr( proc, mod["ECF"+ecfVar],
+				ecf.clone( src = cms.InputTag( mod["PFJetsSoftDrop"] ),
+							cuts = cms.vstring( '', '', ('pt>10000' if not ecfN3 else '' ) ),
+							ecftype = cms.string( ecfType ),
+							alpha = cms.double( ecfBeta ),
+							beta = cms.double( ecfBeta )
+							))
+		elemToKeep += [ 'keep *_'+mod["ECF"+ecfVar]+'_*_*' ]
+		jetSeq += getattr(proc, mod["ECF"+ecfVar])
+		toolsUsed.extend([mod["ECF"+ecfVar]])
 
-		# set up user floats
 		getattr(proc, mod["PATJetsSoftDrop"]).userData.userFloats.src += [
-			mod["ECFnb1"]+':ecfN2',
-			mod["ECFnb1"]+':ecfN3',
-			mod["ECFnb2"]+':ecfN2',
-			mod["ECFnb2"]+':ecfN3',
-		]
-		# rekey the groomed ECF value maps to the ungroomed reco jets, which will then be picked
-		# up by PAT in the user floats. 
+		 			mod["ECF"+ecfVar]+':ecf'+ecfType+'2',
+					mod["ECF"+ecfVar]+':ecf'+ecfType+'3'
+					]
 		mod["PFJetsSoftDropValueMap"] = mod["PFJetsSoftDrop"]+'ValueMap'
 		setattr(proc, mod["PFJetsSoftDropValueMap"],
-			cms.EDProducer("RecoJetToPatJetDeltaRValueMapProducer",
-				src = cms.InputTag(mod["PFJets"]),
-				matched = cms.InputTag(mod["PATJetsSoftDrop"]),
-				distMax = cms.double(jetSize),
-				values = cms.vstring([
-					'userFloat("'+mod["ECFnb1"]+':ecfN2'+'")',
-					'userFloat("'+mod["ECFnb1"]+':ecfN3'+'")',
-					'userFloat("'+mod["ECFnb2"]+':ecfN2'+'")',
-					'userFloat("'+mod["ECFnb2"]+':ecfN3'+'")',
-				]),
-				valueLabels = cms.vstring( [
-					mod["ECFnb1"]+'N2',
-					mod["ECFnb1"]+'N3',
-					mod["ECFnb2"]+'N2',
-					mod["ECFnb2"]+'N3',
-				]),
-			)
-		)
+				cms.EDProducer("RecoJetToPatJetDeltaRValueMapProducer",
+					src = cms.InputTag(mod["PFJets"]),
+					matched = cms.InputTag(mod["PATJetsSoftDrop"]),
+					distMax = cms.double(jetSize),
+					values = cms.vstring([
+						'userFloat("'+mod["ECF"+ecfVar]+':ecf'+ecfType+'2")',
+						'userFloat("'+mod["ECF"+ecfVar]+':ecf'+ecfType+'3")',
+						]),
+					valueLabels = cms.vstring( [
+								mod["ECF"+ecfVar]+ecfType+'2',
+								mod["ECF"+ecfVar]+ecfType+'3',
+								]),
+		 		) )
 		getattr(proc, mod["PATJets"]).userData.userFloats.src += [
-			mod["PFJetsSoftDropValueMap"]+':'+mod["ECFnb1"]+'N2',
-			mod["PFJetsSoftDropValueMap"]+':'+mod["ECFnb1"]+'N3',
-			mod["PFJetsSoftDropValueMap"]+':'+mod["ECFnb2"]+'N2',
-			mod["PFJetsSoftDropValueMap"]+':'+mod["ECFnb2"]+'N3',
-		]
+		 		mod["PFJetsSoftDropValueMap"]+':'+mod["ECF"+ecfVar]+ecfType+'2',
+				mod["PFJetsSoftDropValueMap"]+':'+mod["ECF"+ecfVar]+ecfType+'3' ]
+
 
 	if addEnergyCorrFuncSubjets:
 		if PUMethod!="Puppi" or addSoftDropSubjets==False:
 			raise ValueError("|---- jetToolBox: addEnergyCorrFuncSubjets only supported for Puppi w/ addSoftDropSubjets")
-		from RecoJets.JetProducers.ECF_cff import ecfNbeta1, ecfNbeta2
-		mod["ECFnb1Subjets"] = 'nb1'+mod["SubstructureLabel"]+'SoftDropSubjets'
-		mod["ECFnb2Subjets"] = 'nb2'+mod["SubstructureLabel"]+'SoftDropSubjets'
-		setattr(proc, mod["ECFnb1Subjets"], ecfNbeta1.clone(src = cms.InputTag(mod["PFJetsSoftDrop"],'SubJets')))
-		setattr(proc, mod["ECFnb2Subjets"], ecfNbeta2.clone(src = cms.InputTag(mod["PFJetsSoftDrop"],'SubJets')))
-		elemToKeep += [ 'keep *_'+mod["ECFnb1Subjets"]+'_*_*', 'keep *_'+mod["ECFnb2Subjets"]+'_*_*']
-		jetSeq += getattr(proc, mod["ECFnb1Subjets"])
-		jetSeq += getattr(proc, mod["ECFnb2Subjets"])
-		toolsUsed.extend([mod["ECFnb1Subjets"],mod["ECFnb2Subjets"]])
+		from RecoJets.JetProducers.ECF_cff import ecf
+		ecfSubjetVar = ecfSubjetType.lower()+"b"+str(int(ecfSubjetBeta))+'Subjets'
+		mod["ECF"+ecfSubjetVar] = ecfSubjetType.lower()+"b"+str(int(ecfSubjetBeta))+mod["SubstructureLabel"]+'SoftDropSubjets'
+		setattr(proc, mod["ECF"+ecfSubjetVar],
+				ecf.clone( src = cms.InputTag(mod["PFJetsSoftDrop"],'SubJets'),
+							cuts = cms.vstring( '', '', ('pt>10000' if not ecfSubjetN3 else '' ) ),
+							ecftype = cms.string( ecfSubjetType ),
+							alpha = cms.double( ecfSubjetBeta ),
+							beta = cms.double( ecfSubjetBeta )
+							))
+		elemToKeep += [ 'keep *_'+mod["ECF"+ecfSubjetVar]+'_*_*' ]
+		jetSeq += getattr(proc, mod["ECF"+ecfSubjetVar])
+		toolsUsed.extend([mod["ECFnb"+ecfSubjetVar]])
 
 		# set up user floats
 		getattr(proc, mod["PATSubjetsSoftDrop"]).userData.userFloats.src += [
-			mod["ECFnb1Subjets"]+':ecfN2',
-			mod["ECFnb1Subjets"]+':ecfN3',
-			mod["ECFnb2Subjets"]+':ecfN2',
-			mod["ECFnb2Subjets"]+':ecfN3',
-		]
+						mod["ECF"+ecfSubjetVar]+':ecf'+ecfSubjetType+'2',
+						mod["ECF"+ecfSubjetVar]+':ecf'+ecfSubjetType+'3'
+						]
 
 	if hasattr(proc, 'patJetPartons'): proc.patJetPartons.particles = genParticlesLabel
 
@@ -1063,13 +1057,13 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	### "return"
 	setattr(proc, jetSequence, jetSeq)
 	if hasattr(proc, outputFile): getattr(proc, outputFile).outputCommands += elemToKeep
-	else: setattr( proc, outputFile, 
-			cms.OutputModule('PoolOutputModule', 
-				fileName = cms.untracked.string('jettoolbox.root'), 
+	else: setattr( proc, outputFile,
+			cms.OutputModule('PoolOutputModule',
+				fileName = cms.untracked.string('jettoolbox.root'),
 				outputCommands = cms.untracked.vstring( elemToKeep ) ) )
 
 	##### (Temporary?) fix to replace unschedule mode
-	if hasattr(proc, 'jetTask'): 
+	if hasattr(proc, 'jetTask'):
 		getattr( proc, 'jetTask', cms.Task() ).add(*[getattr(proc,prod) for prod in proc.producers_()])
 		getattr( proc, 'jetTask', cms.Task() ).add(*[getattr(proc,filt) for filt in proc.filters_()])
 	else:
@@ -1078,9 +1072,9 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		getattr( proc, 'jetTask', cms.Task() ).add(*[getattr(proc,filt) for filt in proc.filters_()])
 
 	if associateTask:
-		if hasattr(proc, 'endpath'): 
+		if hasattr(proc, 'endpath'):
 			getattr( proc, 'endpath').associate( getattr( proc, 'jetTask', cms.Task() ) )
-		else: 
+		else:
 			setattr( proc, 'endpath', cms.EndPath(getattr(proc, outputFile), getattr( proc, 'jetTask', cms.Task() )) )
 
 	#### removing mc matching for data

--- a/test/ClusterWithToolboxAndMakeHistos.py
+++ b/test/ClusterWithToolboxAndMakeHistos.py
@@ -1,0 +1,134 @@
+import FWCore.ParameterSet.Config as cms
+###
+### cmsRun ClusterWithToolboxAndPlot.py
+###  make jet plots from miniAOD with some additional jet collections clustered
+### Jet Algorithm HATS 2015 - Dolen, Rappoccio, Stupak
+### Updated for Jet Algorithm HATS 2016 - Dolen, Pilot, Kries, Perloff, Tran
+###
+
+
+process = cms.Process("Ana")
+
+### SETUP
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("Configuration.EventContent.EventContent_cff")
+process.load('Configuration.Geometry.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v1'
+process.GlobalTag.globaltag = '94X_mc2017_realistic_v12'
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.options.allowUnscheduled = cms.untracked.bool(True)
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+### INPUT
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+'/store/mc/RunIISummer17MiniAOD/ZprimeToTT_M-3000_W-300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/NZSFlatPU28to62_92X_upgrade2017_realistic_v10-v1/150000/E45A17E6-AAAC-E711-A423-00266CFFC80C.root'
+    )
+)
+
+
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
+process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
+
+### ADD SOME NEW JET COLLECTIONS
+from JMEAnalysis.JetToolbox.jetToolbox_cff import *
+
+# AK R=0.4 jets from CHS inputs with basic grooming, W tagging, and top tagging
+jetToolbox( process, 'ak4', 'ak4JetSubs', 'out',
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  addTrimming=True, addFiltering=True,
+  addSoftDropSubjets=True,
+  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+  JETCorrPayload = 'AK4PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# AK R=0.8 jets from PF inputs with basic grooming, W tagging, and top tagging
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
+#  PUMethod='Plain',
+#  addPruning=True, addSoftDrop=True ,           # add basic grooming
+#  addTrimming=True, addFiltering=True,
+#  addSoftDropSubjets=True,
+#  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+#  JETCorrPayload = 'AK8PF', JETCorrLevels = ['L2Relative', 'L3Absolute']
+#)
+
+# AK R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  addTrimming=True, addFiltering=True,
+  addSoftDropSubjets=True,
+  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# AK R=0.8 from PUPPI inputs with basic grooming, W tagging, and top tagging
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
+  PUMethod='Puppi',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  addTrimming=True, addFiltering=True,
+  addSoftDropSubjets=True,
+  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+  JETCorrPayload = 'AK8PFPuppi', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# CA R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
+jetToolbox( process, 'ca8', 'ca8JetSubs', 'out',
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  addTrimming=True, addFiltering=True,
+  addSoftDropSubjets=True,
+  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# KT R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
+jetToolbox( process, 'kt8', 'kt8JetSubs', 'out',
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  addTrimming=True, addFiltering=True,
+  addSoftDropSubjets=True,
+  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# AK R=1.2 jets from CHS inputs with basic grooming, W tagging, and top tagging
+jetToolbox( process, 'ak12', 'ak12JetSubs', 'out',
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  addTrimming=True, addFiltering=True,
+  addSoftDropSubjets=True,
+  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# AK R=1.5 jets from CHS inputs with basic grooming, W tagging, and top tagging
+jetToolbox( process, 'ak15', 'ak15JetSubs', 'out',
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  addTrimming=True, addFiltering=True,
+  addSoftDropSubjets=True,
+  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+### MAKE SOME HISTOGRAMS
+process.ana = cms.EDAnalyzer('JetTester'
+)
+
+### OUT
+process.TFileService = cms.Service("TFileService",
+      fileName = cms.string("JetClusterHistos_ZP3.root"),
+      closeFileFast = cms.untracked.bool(True)
+  )
+
+# Uncomment the following line if you would like to output the jet collections in a root file
+# process.endpath = cms.EndPath(process.out)
+
+process.p = cms.Path(process.ana)

--- a/test/jettoolbox_cfg.py
+++ b/test/jettoolbox_cfg.py
@@ -162,24 +162,24 @@ jetToolbox( process, 'ak4', 'jetSequence', 'out', PUMethod='Puppi', miniAOD=True
                 #addNsubSubjets  =True
 				addSoftDropSubjets = True,
                 addEnergyCorrFunc = True, ecfN3 = True,
-                #associateTask=False, #testing !! TO BE CHECKED
+				saveJetCollection = True,
                 )
 
 
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 process.source = cms.Source("PoolSource",
 #		fileNames = cms.untracked.vstring(#'file:example.root'
 		fileNames = cms.untracked.vstring(
-			#'/store/data/Run2016G/JetHT/MINIAOD/PromptReco-v1/000/280/002/00000/E82E26C7-4375-E611-AE7F-FA163E48F736.root'
+			'/store/data/Run2016G/JetHT/MINIAOD/PromptReco-v1/000/280/002/00000/E82E26C7-4375-E611-AE7F-FA163E48F736.root'
 			#'/store/mc/RunIIFall17MiniAOD/QCD_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/02961665-F9F9-E711-87B5-0026B93F49B0.root'
-			'/store/mc/RunIIFall17MiniAODv2/Res1ToRes2GluTo3Glu_M1-2000_R-0p1_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/00000/44F72487-F763-E811-9E6C-6C3BE5B5E4C0.root'
+			#'/store/mc/RunIIFall17MiniAODv2/Res1ToRes2GluTo3Glu_M1-2000_R-0p1_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/00000/44F72487-F763-E811-9E6C-6C3BE5B5E4C0.root'
 			#'/store/relval/CMSSW_9_4_5_cand1/JetHT/MINIAOD/94X_dataRun2_relval_v11_RelVal_rmaod_jetHT2017B-v1/10000/18B5E95F-992E-E811-9422-0CC47A78A418.root'
 			),
 		)
 
-#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
-#process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
+process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 
 #from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
 #process.source.fileNames = filesRelValProdTTbarAODSIM

--- a/test/jettoolbox_cfg.py
+++ b/test/jettoolbox_cfg.py
@@ -19,20 +19,20 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 #process.load("JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff")
 
 ########################################################################
-#### THESE EXAMPLES ARE JUST TESTS, MOST OF THEM ARE TOTALLY WRONG. 
+#### THESE EXAMPLES ARE JUST TESTS, MOST OF THEM ARE TOTALLY WRONG.
 #### THERE ARE JUST TO TEST SEVERAL FEATURES OF THE JETTOOLBOX.
 #######################################################################
 
 from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
 
 '''
-jetToolbox( process, 'ak8', 'jetSequence', 'out', PUMethod='CHS', miniAOD=True, 
+jetToolbox( process, 'ak8', 'jetSequence', 'out', PUMethod='CHS', miniAOD=True,
 		#Cut='pt > 200 && abs(eta) < 2.5', # Tight
 		runOnMC=False,
-		addPruning = True, addSoftDrop = True, 
-		addNsub    = True, 
-		#addPrunedSubjets=True, addSoftDropSubjets=True,  
-		#addNsubSubjets  =True 
+		addPruning = True, addSoftDrop = True,
+		addNsub    = True,
+		#addPrunedSubjets=True, addSoftDropSubjets=True,
+		#addNsubSubjets  =True
 		)
 
 #jetToolbox( process, 'ak4', 'jetSequence', 'out', PUMethod='Puppi', miniAOD=True, runOnMC=True )
@@ -41,95 +41,95 @@ jetToolbox( process, 'ak8', 'jetSequence', 'out', PUMethod='CHS', miniAOD=True,
 #process.PuppiOnTheFly.useExistingWeights = True
 #jetToolbox(process, 'ak4', 'dummy', 'out', PUMethod = 'Puppi', JETCorrPayload = 'AK4PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute'], miniAOD = True, newPFCollection=True, nameNewPFCollection='puppi')
 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='Puppi', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True , JETCorrPayload='AK8PFchs', subJETCorrPayload='AK4PFchs', subJETCorrLevels=['L2Relative', 'L3Absoulte'] ) #, Cut='pt > 100 && abs(eta) < 2.4' ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='Puppi', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, JETCorrLevels=['L1FastJet', 'L2Relative'], newPFCollection=True, nameNewPFCollection='PuppiOnTheFly' ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='SK', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, JETCorrLevels=['L1FastJet', 'L2Relative'] ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, addNsubSubjets=True ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addSoftDropSubjets=True,  addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, addNsubSubjets=True ) 
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', 
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='Puppi', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True , JETCorrPayload='AK8PFchs', subJETCorrPayload='AK4PFchs', subJETCorrLevels=['L2Relative', 'L3Absoulte'] ) #, Cut='pt > 100 && abs(eta) < 2.4' )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='Puppi', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, JETCorrLevels=['L1FastJet', 'L2Relative'], newPFCollection=True, nameNewPFCollection='PuppiOnTheFly' )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='SK', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, JETCorrLevels=['L1FastJet', 'L2Relative'] )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, addNsubSubjets=True )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addSoftDropSubjets=True,  addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, addNsubSubjets=True )
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
 		PUMethod='CHS',
-		#updateCollection='slimmedJetsAK8', 
-		JETCorrPayload='AK8PFchs', 
-		#addEnergyCorrFunc=True, 
-		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets', 
-		#subJETCorrPayload='AK4PFchs', 
-		bTagDiscriminators=listBtagDiscriminatorsAK4, 
-		#addNsubSubjets=True, 
+		#updateCollection='slimmedJetsAK8',
+		JETCorrPayload='AK8PFchs',
+		#addEnergyCorrFunc=True,
+		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets',
+		#subJETCorrPayload='AK4PFchs',
+		bTagDiscriminators=listBtagDiscriminatorsAK4,
+		#addNsubSubjets=True,
 		#addPrunedSubjets=True,
 		postFix= 'CollectionTests',
-		#addTrimming=True, 
-		#addPruning=True 
-		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
-listBtagDiscriminatorsAK4 = [ 
+		#addTrimming=True,
+		#addPruning=True
+		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' )
+listBtagDiscriminatorsAK4 = [
                 #'pfJetProbabilityBJetTags',
                 #'pfCombinedInclusiveSecondaryVertexV2BJetTags',
                 'pfCombinedMVAV2BJetTags',
                 #'pfCombinedCvsLJetTags',
                 #'pfCombinedCvsBJetTags',
                 ]
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', 
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
 		PUMethod='Puppi',
-		#updateCollection='slimmedJetsAK8', 
-		JETCorrPayload='AK8PFPuppi', 
-		#addEnergyCorrFunc=True, 
-		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets', 
-		subJETCorrPayload='AK4PFPuppi', 
-		bTagDiscriminators=listBtagDiscriminatorsAK4, 
-		addNsub    = True, 
-		#addNsubSubjets=True, 
+		#updateCollection='slimmedJetsAK8',
+		JETCorrPayload='AK8PFPuppi',
+		#addEnergyCorrFunc=True,
+		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets',
+		subJETCorrPayload='AK4PFPuppi',
+		bTagDiscriminators=listBtagDiscriminatorsAK4,
+		addNsub    = True,
+		#addNsubSubjets=True,
 		#addPrunedSubjets=True,
 		#postFix= 'NEWCOLLECTIONOFJETS',
-		#addTrimming=True, 
-		#addFiltering=True, 
-		#addPruning=True, 
-		addSoftDrop=True 
-		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
+		#addTrimming=True,
+		#addFiltering=True,
+		#addPruning=True,
+		addSoftDrop=True
+		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' )
 '''
-from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
-listBTagInfos = ['pfInclusiveSecondaryVertexFinderTagInfos','pfImpactParameterTagInfos'] 
-listBtagDiscriminatorsAK8 = [
- 'pfBoostedDoubleSecondaryVertexAK8BJetTags',
-]
-jecLevels = ['L1FastJet', 'L2Relative', 'L3Absolute']
-#if self.residual: jecLevels.append("L2L3Residual")
-jetToolbox(process,
-	'ak8',
-	'jetSequence',
-	'out',
-	PUMethod = 'Puppi',
-	miniAOD = True,
-	#runOnMC = False,
-	postFix='Clean',
-	Cut = 'pt>170.',
-	addPruning = True,
-	addSoftDropSubjets = True,
-	addNsub = True,
-	maxTau = 3,
-	bTagInfos = listBTagInfos, 
-	bTagDiscriminators = listBtagDiscriminatorsAK8,
-	JETCorrLevels = jecLevels,
-	subJETCorrLevels = jecLevels,
-	addEnergyCorrFunc = True,
-)
+#from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
+#listBTagInfos = ['pfInclusiveSecondaryVertexFinderTagInfos','pfImpactParameterTagInfos']
+#listBtagDiscriminatorsAK8 = [
+# 'pfBoostedDoubleSecondaryVertexAK8BJetTags',
+#]
+#jecLevels = ['L1FastJet', 'L2Relative', 'L3Absolute']
+##if self.residual: jecLevels.append("L2L3Residual")
+#jetToolbox(process,
+#	'ak8',
+#	'jetSequence',
+#	'out',
+#	PUMethod = 'Puppi',
+#	miniAOD = True,
+#	#runOnMC = False,
+#	postFix='Clean',
+#	Cut = 'pt>170.',
+#	addPruning = True,
+#	addSoftDropSubjets = True,
+#	addNsub = True,
+#	maxTau = 3,
+#	bTagInfos = listBTagInfos,
+#	bTagDiscriminators = listBtagDiscriminatorsAK8,
+#	JETCorrLevels = jecLevels,
+#	subJETCorrLevels = jecLevels,
+#	addEnergyCorrFunc = True,
+#)
 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', JETCorrPayload = 'AK8PFchs', addEnergyCorrFunc=True, addNsubSubjets=True, addTrimming=True, addFiltering=True, addPruning=True, addSoftDrop=True, addSoftDropSubjets=True )  #PUMethod='CHS', addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' ) 
-
-
-#jetToolbox( process, 'ak4', 'ak4JetSubsUpdate', 'out', updateCollection='slimmedJets', JETCorrPayload = 'AK4PFchs', JETCorrLevels=['L2Relative', 'L3Absolute'], addQGTagger=True, addPUJetID=True, bTagDiscriminators=listBtagDiscriminatorsAK4 ) 
-jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, addPUJetID=True, postFix='New' ) 
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', JETCorrPayload = 'AK8PFchs', addEnergyCorrFunc=True, addNsubSubjets=True, addTrimming=True, addFiltering=True, addPruning=True, addSoftDrop=True, addSoftDropSubjets=True )  #PUMethod='CHS', addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' )
 
 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, JETCorrPayload='AK3Pachs', subJETCorrPayload='AK8PFchs', JETCorrLevels=['L1FastJet', 'L2Relative'], addEnergyCorrFunc=True, maxECF=5 ) 
+#jetToolbox( process, 'ak4', 'ak4JetSubsUpdate', 'out', updateCollection='slimmedJets', JETCorrPayload = 'AK4PFchs', JETCorrLevels=['L2Relative', 'L3Absolute'], addQGTagger=True, addPUJetID=True, bTagDiscriminators=listBtagDiscriminatorsAK4 )
+#jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, addPUJetID=True, postFix='New' )
+
+
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, JETCorrPayload='AK3Pachs', subJETCorrPayload='AK8PFchs', JETCorrLevels=['L1FastJet', 'L2Relative'], addEnergyCorrFunc=True, maxECF=5 )
 #jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', JETCorrPayload='AK4PFchs', JETCorrLevels = ['L1FastJet','L2Relative','L3Absolute'], miniAOD=True, runOnMC=True, addNsub=True, addPUJetID=True, addPruning=False, addTrimming=False, addCMSTopTagger=True, addHEPTopTagger=True, addMassDrop=True, addSoftDrop=False, addQGTagger=True )
 #
-#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', PUMethod='Puppi', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True ) 
-#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', PUMethod='SK', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, JETCorrPayload='AK8PF' ) 
-#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True ) 
-#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, JETCorrPayload='AK8PFchs', JETCorrLevels=['L3Absolute'] ) 
+#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', PUMethod='Puppi', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True )
+#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', PUMethod='SK', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, JETCorrPayload='AK8PF' )
+#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True )
+#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, JETCorrPayload='AK8PFchs', JETCorrLevels=['L3Absolute'] )
 #jetToolbox( process, 'ca12', 'ca12JetSubs', 'out', PUMethod='Puppi', addHEPTopTagger=True, addSoftDrop=True )
 #jetToolbox( process, 'ca12', 'ca12JetSubs', 'out', PUMethod='SK', addHEPTopTagger=True, addSoftDrop=True )
 #jetToolbox( process, 'ca12', 'ca12JetSubs', 'out', addHEPTopTagger=True, addSoftDrop=True )
@@ -140,16 +140,30 @@ jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, addPUJetID=Tr
 #jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', addQGTagger=True, PUMethod='Puppi' )
 
 #
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='Puppi', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False ) 
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='SK', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False ) 
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='Puppi', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False )
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='SK', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False )
 #jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, miniAOD=False )
-#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', PUMethod='Puppi', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, miniAOD=False ) 
-#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', PUMethod='SK', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, miniAOD=False ) 
-#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, miniAOD=False ) 
+#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', PUMethod='Puppi', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, miniAOD=False )
+#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', PUMethod='SK', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, miniAOD=False )
+#jetToolbox( process, 'ca8', 'ca8JetSubs', 'out', addCMSTopTagger=True, addMassDrop=True, addSoftDrop=True, miniAOD=False )
 #jetToolbox( process, 'ca12', 'ca12JetSubs', 'out', PUMethod='Puppi', addHEPTopTagger=True, addSoftDrop=True, miniAOD=False )
 #jetToolbox( process, 'ca12', 'ca12JetSubs', 'out', PUMethod='SK', addHEPTopTagger=True, addSoftDrop=True, miniAOD=False )
 #jetToolbox( process, 'ca12', 'ca12JetSubs', 'out', addHEPTopTagger=True, addSoftDrop=True, miniAOD=False )
 
+jetToolbox( process, 'ak4', 'jetSequence', 'out', PUMethod='Puppi', miniAOD=True,
+                #Cut='pt > 200 && abs(eta) < 2.5', # Tight
+                #nameNewPFCollection='hltScoutingPFPacker',
+                #nameNewPFCollection='pippo',
+				#addPruning = True,
+		  		addSoftDrop = True,
+				#addFiltering=True,
+                #addNsub    = True,
+                #addPrunedSubjets=True, addSoftDropSubjets=True,
+                #addNsubSubjets  =True
+				addSoftDropSubjets = True,
+                addEnergyCorrFunc = True, ecfN3 = True,
+                #associateTask=False, #testing !! TO BE CHECKED
+                )
 
 
 
@@ -158,7 +172,8 @@ process.source = cms.Source("PoolSource",
 #		fileNames = cms.untracked.vstring(#'file:example.root'
 		fileNames = cms.untracked.vstring(
 			#'/store/data/Run2016G/JetHT/MINIAOD/PromptReco-v1/000/280/002/00000/E82E26C7-4375-E611-AE7F-FA163E48F736.root'
-			'/store/mc/RunIIFall17MiniAOD/QCD_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/02961665-F9F9-E711-87B5-0026B93F49B0.root'
+			#'/store/mc/RunIIFall17MiniAOD/QCD_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/02961665-F9F9-E711-87B5-0026B93F49B0.root'
+			'/store/mc/RunIIFall17MiniAODv2/Res1ToRes2GluTo3Glu_M1-2000_R-0p1_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/00000/44F72487-F763-E811-9E6C-6C3BE5B5E4C0.root'
 			#'/store/relval/CMSSW_9_4_5_cand1/JetHT/MINIAOD/94X_dataRun2_relval_v11_RelVal_rmaod_jetHT2017B-v1/10000/18B5E95F-992E-E811-9422-0CC47A78A418.root'
 			),
 		)
@@ -168,4 +183,3 @@ process.source = cms.Source("PoolSource",
 
 #from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
 #process.source.fileNames = filesRelValProdTTbarAODSIM
-

--- a/test/testJTB_fwlite.py
+++ b/test/testJTB_fwlite.py
@@ -29,9 +29,9 @@ events = Events ('jettoolbox.root')
 PUMethod = 'CHS'
 
 handle = Handle("std::vector<pat::Jet>")
-label = ("selectedPatJetsAK8PF"+PUMethod) 
+#label = ("selectedPatJetsAK8PF"+PUMethod) 
 #label = ('packedPatJetsAK8PFCHSSoftDrop') 
-#label = ('packedPatJetsAK8PFCHSPruned') 
+label = ('packedPatJetsAK4PFPuppiSoftDrop') 
 
 
 # loop over events in this file
@@ -48,7 +48,8 @@ for event in events:
 	#subjets = handleSubjets.product()
 
 	for i,j in enumerate(jets):
-		print "jetAK8 %3d: pt %5.1f (raw pt %5.1f), eta %+4.2f, mass %5.1f ungroomed, %5.1f softdrop, %5.1f pruned, %5.1f trimmed, %5.1f filtered. " % ( i, j.pt(), j.pt()*j.jecFactor('Uncorrected'), j.eta(), j.mass(), j.userFloat('ak8PFJetsCHSSoftDropMass'), j.userFloat('ak8PFJetsCHSPrunedMass'), j.userFloat('ak8PFJetsCHSTrimmedMass'), j.userFloat('ak8PFJetsCHSFilteredMass'))
+		#print "jetAK8 %3d: pt %5.1f (raw pt %5.1f), eta %+4.2f, mass %5.1f ungroomed, %5.1f softdrop, %5.1f pruned, %5.1f trimmed, %5.1f filtered. " % ( i, j.pt(), j.pt()*j.jecFactor('Uncorrected'), j.eta(), j.mass(), j.userFloat('ak8PFJetsCHSSoftDropMass'), j.userFloat('ak8PFJetsCHSPrunedMass'), j.userFloat('ak8PFJetsCHSTrimmedMass'), j.userFloat('ak8PFJetsCHSFilteredMass'), j.userFloat('nb2AK4PuppiSoftDrop:ecfN2'))
+		print  i, j.pt(), j.pt()*j.jecFactor('Uncorrected'), j.eta(), j.mass(), j.userFloat('ak4PFJetsPuppiSoftDropValueMap:nb1AK4PuppiSoftDropN2'), j.userFloat('ak4PFJetsPuppiSoftDropValueMap:nb1AK4PuppiSoftDropN3')
 			          
 		'''
 	i = 0


### PR DESCRIPTION
- Fixing the ECF to include parameters of the algorithm and reduce time by not calculating all the variables N2 and N3
- changing associateTask parameter to saveJetCollection.  By default it run the jetToolbox and not save the jetCollection in the edm rootfile (to avoid the creation of jettoolbox.root). If needed (saveJetCollection=True) the pat:Jet collection is saved.
- adding meaningful test (using one of the [CMSDAS examples](https://github.com/cms-jet/JMEDAS/blob/1eb13c61db330a3cb4500bcf93ef87be24c74162/test/ClusterWithToolboxAndMakeHistos.py)) 