### PR TITLE
Fixing bug in saveJetCollection option

### DIFF
--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -52,7 +52,6 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		addQGTagger=False, QGjetsLabel='chs',
 		addEnergyCorrFunc=False, ecfType = "N", ecfBeta = 1.0, ecfN3 = False,
 		addEnergyCorrFuncSubjets=False, ecfSubjetType = "N", ecfSubjetBeta = 1.0, ecfSubjetN3 = False,
-		saveJetCollection=False,    # set this to true to enable creation of edm root file
 		verbosity=2, 	# 0 = no printouts, 1 = warnings only, 2 = warnings & info, 3 = warnings, info, debug
 		):
 
@@ -1204,21 +1203,19 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	#################################################################################
 	###### Adding to outputModule OR creating output file
 	setattr(proc, jetSequence, jetSeq)
-        if outputFile!='':
-            if hasattr(proc, outputFile): getattr(proc, outputFile).outputCommands += elemToKeep
-            else: setattr( proc, outputFile,
-			cms.OutputModule('PoolOutputModule',
-				fileName = cms.untracked.string('jettoolbox.root'),
-				outputCommands = cms.untracked.vstring( elemToKeep ) ) )
+        if hasattr(proc, outputFile): getattr(proc, outputFile).outputCommands += elemToKeep
+        else: setattr( proc, outputFile,
+                    cms.OutputModule('PoolOutputModule',
+                            fileName = cms.untracked.string('jettoolbox.root'),
+                            outputCommands = cms.untracked.vstring( elemToKeep ) ) )
 
-	#################################################################################
-	##### fix to replace unschedule mode
-	if saveJetCollection:
-		task = getPatAlgosToolsTask(proc)
-	 	if hasattr(proc, 'endpath'):
-			getattr(proc, 'endpath').associate(task)
-	 	else:
-	 		setattr( proc, 'endpath', cms.EndPath(getattr(proc, outputFile), task) )
+        task = getPatAlgosToolsTask(proc)
+        if hasattr(proc, 'endpath'):
+            getattr(proc, 'endpath').associate(task)
+        else:
+            if outputFile=='noOutput':
+                setattr( proc, 'endpath', cms.EndPath(task) )
+            else: setattr( proc, 'endpath', cms.EndPath(getattr(proc, outputFile), task) )
 
 	#################################################################################
 	#### removing mc matching for data

--- a/test/ClusterWithToolboxAndMakeHistos.py
+++ b/test/ClusterWithToolboxAndMakeHistos.py
@@ -39,7 +39,7 @@ process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 from JMEAnalysis.JetToolbox.jetToolbox_cff import *
 
 # AK R=0.4 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak4', 'ak4JetSubs', 'out',
+jetToolbox( process, 'ak4', 'ak4JetSubs', 'noOutput',
   PUMethod='CHS',
   addPruning=True, addSoftDrop=True ,           # add basic grooming
   addTrimming=True, addFiltering=True,
@@ -49,7 +49,7 @@ jetToolbox( process, 'ak4', 'ak4JetSubs', 'out',
 )
 
 # AK R=0.8 jets from PF inputs with basic grooming, W tagging, and top tagging
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
+#jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
 #  PUMethod='Plain',
 #  addPruning=True, addSoftDrop=True ,           # add basic grooming
 #  addTrimming=True, addFiltering=True,
@@ -59,7 +59,7 @@ jetToolbox( process, 'ak4', 'ak4JetSubs', 'out',
 #)
 
 # AK R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
   PUMethod='CHS',
   addPruning=True, addSoftDrop=True ,           # add basic grooming
   addTrimming=True, addFiltering=True,
@@ -69,7 +69,7 @@ jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
 )
 
 # AK R=0.8 from PUPPI inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
   PUMethod='Puppi',
   addPruning=True, addSoftDrop=True ,           # add basic grooming
   addTrimming=True, addFiltering=True,
@@ -79,7 +79,7 @@ jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
 )
 
 # CA R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ca8', 'ca8JetSubs', 'out',
+jetToolbox( process, 'ca8', 'ca8JetSubs', 'noOutput',
   PUMethod='CHS',
   addPruning=True, addSoftDrop=True ,           # add basic grooming
   addTrimming=True, addFiltering=True,
@@ -89,7 +89,7 @@ jetToolbox( process, 'ca8', 'ca8JetSubs', 'out',
 )
 
 # KT R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'kt8', 'kt8JetSubs', 'out',
+jetToolbox( process, 'kt8', 'kt8JetSubs', 'noOutput',
   PUMethod='CHS',
   addPruning=True, addSoftDrop=True ,           # add basic grooming
   addTrimming=True, addFiltering=True,
@@ -99,7 +99,7 @@ jetToolbox( process, 'kt8', 'kt8JetSubs', 'out',
 )
 
 # AK R=1.2 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak12', 'ak12JetSubs', 'out',
+jetToolbox( process, 'ak12', 'ak12JetSubs', 'noOutput',
   PUMethod='CHS',
   addPruning=True, addSoftDrop=True ,           # add basic grooming
   addTrimming=True, addFiltering=True,
@@ -109,7 +109,7 @@ jetToolbox( process, 'ak12', 'ak12JetSubs', 'out',
 )
 
 # AK R=1.5 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak15', 'ak15JetSubs', 'out',
+jNoSaveetToolbox( process, 'ak15', 'ak15JetSubs', 'noOutput',
   PUMethod='CHS',
   addPruning=True, addSoftDrop=True ,           # add basic grooming
   addTrimming=True, addFiltering=True,


### PR DESCRIPTION
Removing saveJetCollection option, to avoid the creation of jetToolbox.root file. Instead if the name of the output module is "noOutput" no JetCollection is saved and no jetToolbox.root file is created.