### PR TITLE
jetToolbox with NanoAOD option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Python framework for configuration of jet tools via the jet toolbox.
 Check the branch for the correspondent release. This branch is for *CMSSW_10_2_X* and higher. 
 Then for example:
 ```
-cmsrel CMSSW_10_2_9/
-cd CMSSW_10_2_9/src/
+cmsrel CMSSW_10_2_15/
+cd CMSSW_10_2_15/src/
 git cms-init
 git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_102X_v1
 scram b -j 18

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ cmsRun JMEAnalysis/JetToolbox/test/ClusterWithToolboxAndMakeHistos.py
 ~~~
 In this python file you also can see a basic example on how to use the toolbox.
 
-## Instruction to run jetToolbox in nanoAOD (beta version)
+## Instruction to produce modified nanoAOD with the jetToolbox (beta version)
 
-This is a beta version on how to modify nanoAOD production to incorporate different jet collections in nanoAOD format.
+This is a beta version on how to modify nanoAOD production to incorporate different jet collections in nanoAOD format. This will create the standard nanoAOD variables plus new variables run by the jetToolbox.
 
 The only file that needs to be modified is [JMEAnalysis/JetToolbox/python/nanoAOD_jetToolbox_cff.py](python/nanoAOD_jetToolbox_cff.py), using the same setting as in the miniAOD case.
 *The main change is the dataTier parameter, in case of nanoAOD:* `dataTier="nanoAOD"`.
@@ -37,12 +37,12 @@ After modify the `setupCustomizedJetToolbox` function in that file, one can run 
 cmsDriver.py nanoAOD_jetToolbox_cff -s NANO --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --no_exec --conditions 102X_upgrade2018_realistic_v19 --era Run2_2018,run2_nanoAOD_102Xv1 --customise_commands="process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)))" --customise JMEAnalysis/JetToolbox/nanoAOD_jetToolbox_cff.nanoJTB_customizeMC --filein /store/mc/RunIIAutumn18MiniAOD/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15_ext1-v2/20000/7E65457A-87E5-C146-8321-9A48B4F56ED1.root --fileout file:jetToolbox_nano_mc.root
 ~~~
 
-Notice that the `--customise` option points to the file [JMEAnalysis/JetToolbox/python/nanoAOD_jetToolbox_cff.py](python/nanoAOD_jetToolbox_cff). 
+Notice that the `--customise` option points to the file [JMEAnalysis/JetToolbox/python/nanoAOD_jetToolbox_cff.py](python/nanoAOD_jetToolbox_cff.py). 
 
 
 A working example, after running the cmsDriver command shown above, is located here: [JMEAnalysis/JetToolbox/test/jetToolbox_nanoAODv05_cfg.py](test/jetToolbox_nanoAODv05_cfg.py). 
 
-All the variables created by the jetToolbox start with `selectedJet`.
+All the variables created by the jetToolbox start with `selectedPatJets**`.
 
 
 ## More Information

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ Python framework for configuration of jet tools via the jet toolbox.
 
 ## Instructions
 
+### Notice that the parameter `miniAOD=True` has changed to `dataTier=miniAOD`
+
 Check the branch for the correspondent release. This branch is for *CMSSW_10_2_X* and higher. 
 Then for example:
 ```
 cmsrel CMSSW_10_2_15/
 cd CMSSW_10_2_15/src/
 git cms-init
-git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_102X_v1
+git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_102X_v2
 scram b -j 18
 ```
 
@@ -22,6 +24,25 @@ This config file run only a test of the capabilities of the jetToolbox, it is ph
 cmsRun JMEAnalysis/JetToolbox/test/ClusterWithToolboxAndMakeHistos.py
 ~~~
 In this python file you also can see a basic example on how to use the toolbox.
+
+## Instruction to run jetToolbox in nanoAOD (beta version)
+
+This is a beta version on how to modify nanoAOD production to incorporate different jet collections in nanoAOD format.
+
+The only file that needs to be modified is [JMEAnalysis/JetToolbox/python/nanoAOD_jetToolbox_cff.py](python/nanoAOD_jetToolbox_cff.py), using the same setting as in the miniAOD case.
+*The main change is the dataTier parameter, in case of nanoAOD:* `dataTier="nanoAOD"`.
+After modify the `setupCustomizedJetToolbox` function in that file, one can run a cmsDriver command. For instance (for nanoAOD v5 2018):
+
+~~~
+cmsDriver.py nanoAOD_jetToolbox_cff -s NANO --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --no_exec --conditions 102X_upgrade2018_realistic_v19 --era Run2_2018,run2_nanoAOD_102Xv1 --customise_commands="process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)))" --customise JMEAnalysis/JetToolbox/nanoAOD_jetToolbox_cff.nanoJTB_customizeMC --filein /store/mc/RunIIAutumn18MiniAOD/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15_ext1-v2/20000/7E65457A-87E5-C146-8321-9A48B4F56ED1.root --fileout file:jetToolbox_nano_mc.root
+~~~
+
+Notice that the `--customise` option points to the file [JMEAnalysis/JetToolbox/python/nanoAOD_jetToolbox_cff.py](python/nanoAOD_jetToolbox_cff). 
+
+
+A working example, after running the cmsDriver command shown above, is located here: [JMEAnalysis/JetToolbox/test/jetToolbox_nanoAODv05_cfg.py](test/jetToolbox_nanoAODv05_cfg.py). 
+
+All the variables created by the jetToolbox start with `selectedJet`.
 
 
 ## More Information

--- a/plugins/JetTester.cc
+++ b/plugins/JetTester.cc
@@ -1324,16 +1324,16 @@ JetTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   //--------------------------------------------------------------------------------------------
   // CA R=1.2 jets - from toolbox
 
-  edm::Handle<pat::JetCollection> CA12CHS;
+  /*edm::Handle<pat::JetCollection> CA12CHS;
   iEvent.getByToken(ca12PFCHSjetToken_, CA12CHS);
 
   for (const pat::Jet &ijet : *CA12CHS) {  
         //cout << ijet.tagInfoLabels() << endl;
         cout << ijet.tagInfo("hepTopTagPFJetsCHS") << endl;
-      /*for ( auto st : ijet.tagInfoLabels() ) {
+      //for ( auto st : ijet.tagInfoLabels() ) {
         cout << st << endl; //ijet.tagInfo("CATop") << endl;
-      }*/
-  }
+      }//
+  }*/
   
 
 

--- a/plugins/JetTester.cc
+++ b/plugins/JetTester.cc
@@ -820,7 +820,7 @@ JetTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   using namespace std;
   using namespace reco;
   using namespace pat;
-  bool verbose = false;
+  //bool verbose = false;
 
   //--------------------------------------------------------------------------------------------
   // AK R=0.4 CHS jets - from miniAOD

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -325,7 +325,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					_addProcessAndTask( proc, 'newParticleFlowTmpPtrs', particleFlowTmpPtrs.clone( src = pfCand ) )
 					jetSeq += getattr(proc, 'newParticleFlowTmpPtrs')
 					from CommonTools.ParticleFlow.pfNoPileUpJME_cff import pfPileUpJME, pfNoPileUpJME
-					proc.load('CommonTools.ParticleFlow.goodOfflinePrimaryVertices_cfi')
+					from CommonTools.ParticleFlow.goodOfflinePrimaryVertices_cfi import goodOfflinePrimaryVertices
+					_addProcessAndTask( proc, 'goodOfflinePrimaryVertices', goodOfflinePrimaryVertices.clone( ) )
 					_addProcessAndTask( proc, 'newPfPileUpJME', pfPileUpJME.clone( PFCandidates= 'newParticleFlowTmpPtrs' ) )
 					jetSeq += getattr(proc, 'newPfPileUpJME')
 					_addProcessAndTask( proc, 'newPfNoPileUpJME', pfNoPileUpJME.clone( topCollection='newPfPileUpJME', bottomCollection= 'newParticleFlowTmpPtrs' ) )

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -1315,7 +1315,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 	#_addProcessAndTask( proc, mod["selPATJets"], selectedPatJets.clone( src = mod["PATJets"], cut = Cut ) )
 	_addProcessAndTask( proc, mod["selPATJets"], cms.EDFilter("PATJetRefSelector", src = cms.InputTag(mod["PATJetswithUserData"]), cut = cms.string( Cut ) ) )
-	elemToKeep += [ 'keep *_'+mod["selPATJets"]+'_*_*'
+	elemToKeep += [ 'keep *_'+mod["selPATJets"]+'_*_*' ]
 	elemToKeep += [ 'drop *_'+mod["selPATJets"]+'_calo*_*' ]
 	elemToKeep += [ 'drop *_'+mod["selPATJets"]+'_tagInfos_*' ]
 

--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -1314,8 +1314,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 	###### Saving jet collections
 	if hasattr(proc, 'patJetPartons'): proc.patJetPartons.particles = genParticlesLabel
 
-	#_addProcessAndTask( proc, mod["selPATJets"], selectedPatJets.clone( src = mod["PATJets"], cut = Cut ) )
-	_addProcessAndTask( proc, mod["selPATJets"], cms.EDFilter("PATJetRefSelector", src = cms.InputTag(mod["PATJetswithUserData"]), cut = cms.string( Cut ) ) )
+        if dataTier.startswith("nanoAOD"): _addProcessAndTask( proc, mod["selPATJets"], cms.EDFilter("PATJetRefSelector", src = cms.InputTag(mod["PATJetswithUserData"]), cut = cms.string( Cut ) ) )
+        else: _addProcessAndTask( proc, mod["selPATJets"], selectedPatJets.clone( src = mod["PATJets"], cut = Cut ) )
 	elemToKeep += [ 'keep *_'+mod["selPATJets"]+'_*_*' ]
 	elemToKeep += [ 'drop *_'+mod["selPATJets"]+'_calo*_*' ]
 	elemToKeep += [ 'drop *_'+mod["selPATJets"]+'_tagInfos_*' ]
@@ -1388,6 +1388,9 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
             ))
 
             for varName, varDef in jetVariables.iteritems(): setattr( getattr( proc, mod['jetToolboxJetTable'] ).variables, varName.replace(":","_"), varDef )
+            if runOnMC:
+                setattr( getattr( proc, mod['jetToolboxJetTable'] ).variables,  'partonFlavor', Var('partonFlavour()', int, doc="flavour from parton matching" ) )
+                setattr( getattr( proc, mod['jetToolboxJetTable'] ).variables,  'hadronFlavor', Var('hadronFlavour()', int, doc="flavour from hadron matching" ) )
 
             if addPrunedSubjets or addSoftDropSubjets:
                 setattr( getattr( proc, mod['jetToolboxJetTable'] ).variables, 'subJetIdx1', Var("?nSubjetCollections()>0 && subjets().size()>0?subjets()[0].key():-1", int, doc="index of first subjet") ),

--- a/python/nanoAOD_jetToolbox_cff.py
+++ b/python/nanoAOD_jetToolbox_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+from  PhysicsTools.NanoAOD.common_cff import *
+### NanoAOD v5 (for 2016,2017,2018), for different recipe please modify accordingly
+from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
+from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv2_cff import run2_nanoAOD_94XMiniAODv2
+from Configuration.Eras.Modifier_run2_nanoAOD_102Xv1_cff import run2_nanoAOD_102Xv1
+
+# ---------------------------------------------------------
+# This is the part the user should modify
+def setupCustomizedJetToolbox(process):
+
+    # recluster Puppi jets, add N-Subjettiness and ECF
+    bTagDiscriminators = [
+        #'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+        #'pfBoostedDoubleSecondaryVertexAK8BJetTags',
+        'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
+        'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
+        #'pfDeepCSVJetTags:probb',
+        #'pfDeepCSVJetTags:probbb',
+    ]
+    subjetBTagDiscriminators = [
+        'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+        'pfDeepCSVJetTags:probb',
+        'pfDeepCSVJetTags:probbb',
+    ]
+    JETCorrLevels = ['L2Relative', 'L3Absolute', 'L2L3Residual']
+
+    from JMEAnalysis.JetToolbox.jetToolbox_cff_withNanoAOD import jetToolbox
+    jetToolbox(process, 'ak8', 'dummyseq', 'noOutput',
+               dataTier='nanoAOD',
+               PUMethod='Puppi', JETCorrPayload='AK4PFPuppi', JETCorrLevels=JETCorrLevels,
+               #addQGTagger=True,
+               Cut='pt > 170.0 && abs(rapidity()) < 2.4',
+               runOnMC=True,
+               addNsub=True, maxTau=3, addEnergyCorrFunc=True,
+               addSoftDrop=True, addSoftDropSubjets=True, subJETCorrPayload='AK4PFPuppi', subJETCorrLevels=JETCorrLevels,
+               #bTagDiscriminators=bTagDiscriminators,
+               #subjetBTagDiscriminators=subjetBTagDiscriminators
+               )
+
+# ---------------------------------------------------------
+
+def nanoJTB_customizeMC(process):
+    run2_nanoAOD_94X2016.toModify(process, setupCustomizedJetToolbox)
+    run2_nanoAOD_94XMiniAODv2.toModify(process, setupCustomizedJetToolbox)
+    run2_nanoAOD_102Xv1.toModify(process, setupCustomizedJetToolbox)
+    process.NANOAODSIMoutput.fakeNameForCrab = cms.untracked.bool(True)  # needed for crab publication
+    return process

--- a/python/nanoAOD_jetToolbox_cff.py
+++ b/python/nanoAOD_jetToolbox_cff.py
@@ -4,39 +4,69 @@ from  PhysicsTools.NanoAOD.common_cff import *
 from Configuration.Eras.Modifier_run2_nanoAOD_94X2016_cff import run2_nanoAOD_94X2016
 from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv2_cff import run2_nanoAOD_94XMiniAODv2
 from Configuration.Eras.Modifier_run2_nanoAOD_102Xv1_cff import run2_nanoAOD_102Xv1
+from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
 
 # ---------------------------------------------------------
 # This is the part the user should modify
 def setupCustomizedJetToolbox(process):
 
-    # recluster Puppi jets, add N-Subjettiness and ECF
-    bTagDiscriminators = [
-        #'pfCombinedInclusiveSecondaryVertexV2BJetTags',
-        #'pfBoostedDoubleSecondaryVertexAK8BJetTags',
-        'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
-        'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
-        #'pfDeepCSVJetTags:probb',
-        #'pfDeepCSVJetTags:probbb',
-    ]
-    subjetBTagDiscriminators = [
-        'pfCombinedInclusiveSecondaryVertexV2BJetTags',
-        'pfDeepCSVJetTags:probb',
-        'pfDeepCSVJetTags:probbb',
-    ]
-    JETCorrLevels = ['L2Relative', 'L3Absolute', 'L2L3Residual']
+    #### AK4 PUPPI jets
 
-    from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
-    jetToolbox(process, 'ak8', 'dummyseq', 'noOutput',
+    ak4btagdiscriminators = [
+            'pfDeepCSVJetTags:probb',
+            'pfDeepCSVJetTags:probbb',
+            'pfDeepCSVJetTags:probc',
+            'pfDeepCSVJetTags:probudsg',
+#            'pfDeepFlavourJetTags:probb',
+#            'pfDeepFlavourJetTags:probbb',
+#            'pfDeepFlavourJetTags:problepb',
+#            'pfDeepFlavourJetTags:probc',
+#            'pfDeepFlavourJetTags:probuds',
+#            'pfDeepFlavourJetTags:probg',
+    ]
+    ak4btaginfos = [ 'pfDeepCSVTagInfos' ] #'pfDeepFlavourTagInfos'
+
+    jetToolbox(process, 'ak4', 'dummyseq', 'noOutput',
                dataTier='nanoAOD',
-               PUMethod='Puppi', JETCorrPayload='AK4PFPuppi', JETCorrLevels=JETCorrLevels,
+               PUMethod='Puppi', JETCorrPayload='AK4PFPuppi',
                #addQGTagger=True,
-               Cut='pt > 170.0 && abs(rapidity()) < 2.4',
                runOnMC=True,
-               addNsub=True, maxTau=3, addEnergyCorrFunc=True,
-               addSoftDrop=True, addSoftDropSubjets=True, subJETCorrPayload='AK4PFPuppi', subJETCorrLevels=JETCorrLevels,
-               #bTagDiscriminators=bTagDiscriminators,
-               #subjetBTagDiscriminators=subjetBTagDiscriminators
+               Cut='pt > 15.0 && abs(eta) < 2.4',
+               bTagDiscriminators=ak4btagdiscriminators,
+               bTagInfos=ak4btaginfos,
+               verbosity=4
                )
+
+    #### AK8 PUPPI jets
+    ak8btagdiscriminators = [
+                        'pfBoostedDoubleSecondaryVertexAK8BJetTags',
+                        'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
+                        'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
+                        'pfMassIndependentDeepDoubleCvLJetTags:probQCD',
+                        'pfMassIndependentDeepDoubleCvLJetTags:probHcc',
+                        'pfMassIndependentDeepDoubleCvBJetTags:probHbb',
+                        'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
+#                        "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight",
+#                        "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ccvsLight",
+#                        "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:TvsQCD",
+#                        "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD",
+#                        "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD",
+#                        "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD"
+            ]
+
+    jetToolbox(process, 'ak8', 'adummyseq', 'noOutput',
+               dataTier='nanoAOD',
+               PUMethod='Puppi', JETCorrPayload='AK8PFPuppi',
+               runOnMC=True,
+               Cut='pt > 170.0 && abs(eta) < 2.4',
+               bTagDiscriminators=ak8btagdiscriminators,
+               addSoftDrop=True,
+               addSoftDropSubjets=True,
+               addPruning=True,
+               addNsub=True,
+               addEnergyCorrFunc=True,
+               )
+    return process
 
 # ---------------------------------------------------------
 

--- a/python/nanoAOD_jetToolbox_cff.py
+++ b/python/nanoAOD_jetToolbox_cff.py
@@ -25,7 +25,7 @@ def setupCustomizedJetToolbox(process):
     ]
     JETCorrLevels = ['L2Relative', 'L3Absolute', 'L2L3Residual']
 
-    from JMEAnalysis.JetToolbox.jetToolbox_cff_withNanoAOD import jetToolbox
+    from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
     jetToolbox(process, 'ak8', 'dummyseq', 'noOutput',
                dataTier='nanoAOD',
                PUMethod='Puppi', JETCorrPayload='AK4PFPuppi', JETCorrLevels=JETCorrLevels,

--- a/test/ClusterWithToolboxAndMakeHistos.py
+++ b/test/ClusterWithToolboxAndMakeHistos.py
@@ -23,7 +23,7 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 
 ### INPUT
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
@@ -31,92 +31,195 @@ process.source = cms.Source("PoolSource",
     )
 )
 
-
 from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
 process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
+
+btagDiscAK4 = [
+            'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+            'pfCombinedCvsLJetTags',
+            'pfCombinedCvsBJetTags',
+            'pfDeepCSVJetTags:probb',
+            'pfDeepCSVJetTags:probbb',
+            'pfDeepCSVJetTags:probc',
+            'pfDeepCSVJetTags:probudsg',
+            'pfDeepFlavourJetTags:probb',
+            'pfDeepFlavourJetTags:probbb',
+            'pfDeepFlavourJetTags:problepb',
+            'pfDeepFlavourJetTags:probc',
+            'pfDeepFlavourJetTags:probuds',
+            'pfDeepFlavourJetTags:probg',
+        ]
+
+btagDiscAK8 = [
+            'pfBoostedDoubleSecondaryVertexAK8BJetTags',
+            #'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
+            #'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
+            #'pfMassIndependentDeepDoubleCvLJetTags:probQCD',
+            #'pfMassIndependentDeepDoubleCvLJetTags:probHcc',
+            #'pfMassIndependentDeepDoubleCvBJetTags:probHbb',
+            #'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
+	    "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight",
+	    "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ccvsLight",
+	    "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:TvsQCD",
+	    "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD",
+ 	    "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD",
+ 	    "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD"
+            ]
 
 ### ADD SOME NEW JET COLLECTIONS
 from JMEAnalysis.JetToolbox.jetToolbox_cff import *
 
-# AK R=0.4 jets from CHS inputs with basic grooming, W tagging, and top tagging
+# updating slimmedJets (ak4 CHS jets) from miniAOD
+jetToolbox( process, 'ak4', 'ak4UpdJetSubs', 'noOutput',
+        dataTier="miniAOD",
+        updateCollection='slimmedJets',
+        JETCorrPayload='AK4PFchs',
+        postFix='Updated',
+        bTagDiscriminators=btagDiscAK4
+        )
+
+# AK R=0.4 jets from CHS inputs
 jetToolbox( process, 'ak4', 'ak4JetSubs', 'noOutput',
+  dataTier="miniAOD",
+  PUMethod='CHS',
+#  JETCorrPayload = 'AK4PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+  addPUJetID=True,
+  addQGTagger=True,
+  Cut='pt>30 && abs(eta)<2.5'
+)
+
+# AK R=0.4 jets from Puppi inputs
+jetToolbox( process, 'ak4', 'ak4JetSubs', 'noOutput',
+  dataTier="miniAOD",
+  PUMethod='Puppi',
+#  JETCorrPayload = 'AK4PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+  Cut='pt>30 && abs(eta)<2.5'
+)
+
+# AK R=0.4 jets from PF inputs
+jetToolbox( process, 'ak4', 'ak4JetSubs', 'noOutput',
+  dataTier="miniAOD",
+  PUMethod='Plain',
+#  JETCorrPayload = 'AK4PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+  Cut='pt>30 && abs(eta)<2.5'
+)
+
+
+
+# updating slimmedAK8Jets (ak8 puppi jets) from miniAOD
+jetToolbox( process, 'ak8', 'ak8UpdJetSubs', 'noOutput',
+        dataTier="miniAOD",
+        PUMethod='Puppi',
+        updateCollection='slimmedJetsAK8',
+        JETCorrPayload='AK8PFPuppi',
+        postFix='Updated',
+        bTagDiscriminators=btagDiscAK8
+        )
+
+# AK R=0.8 jets from CHS
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
+  dataTier="miniAOD",
+  Cut="pt>170 && abs(eta)<2.5",
   PUMethod='CHS',
   addPruning=True, addSoftDrop=True ,           # add basic grooming
   addTrimming=True, addFiltering=True,
   addSoftDropSubjets=True,
   addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-  JETCorrPayload = 'AK4PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute'],
 )
 
-# AK R=0.8 jets from PF inputs with basic grooming, W tagging, and top tagging
+# AK R=0.8 from PUPPI
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
+  dataTier="miniAOD",
+  PUMethod='Puppi',
+  Cut="pt>170 && abs(eta)<2.5",
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  addTrimming=True, addFiltering=True,
+  addSoftDropSubjets=True,
+  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+  addEnergyCorrFunc=True,
+  #JETCorrPayload = 'AK8PFPuppi', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# CA R=0.8 jets from CHS
+jetToolbox( process, 'ca8', 'ca8JetSubs', 'noOutput',
+  Cut="pt>170 && abs(eta)<2.5",
+  dataTier="miniAOD",
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# KT R=0.8 jets from CHS
+jetToolbox( process, 'kt8', 'kt8JetSubs', 'noOutput',
+  Cut="pt>170 && abs(eta)<2.5",
+  dataTier="miniAOD",
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# KT R=0.8 jets from CHS
+jetToolbox( process, 'kt8', 'kt8JetSubs', 'noOutput',
+  dataTier="miniAOD",
+  Cut="pt>170 && abs(eta)<2.5",
+  PUMethod='CHS',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# AK R=0.8 jets from Puppi, modified Softdrop
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
+  dataTier="miniAOD",
+  Cut="pt>170 && abs(eta)<2.5",
+  PUMethod='Puppi',
+  postFix='modSD',
+  addSoftDrop=True , betaCut=1,           # add basic grooming
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+# AK R=0.8 jets from SK
+jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
+  dataTier="miniAOD",
+  Cut="pt>170 && abs(eta)<2.5",
+  PUMethod='SK',
+  addPruning=True, addSoftDrop=True ,           # add basic grooming
+  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+)
+
+## AK R=0.8 jets from CS
 #jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
-#  PUMethod='Plain',
+#  PUMethod='CS',
+#  addPruning=True, addSoftDrop=True ,           # add basic grooming
+#  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+#)
+
+# CA R=1.2 jets from CHS inputs with basic grooming, W tagging, and top tagging
+#jetToolbox( process, 'ca12', 'ca12JetSubs', 'noOutput',
+#  PUMethod='CHS',
+#  addHEPTopTagger=True,
+#)
+
+
+## AK R=1.2 jets from CHS inputs with basic grooming, W tagging, and top tagging
+#jetToolbox( process, 'ak12', 'ak12JetSubs', 'noOutput',
+#  PUMethod='CHS',
 #  addPruning=True, addSoftDrop=True ,           # add basic grooming
 #  addTrimming=True, addFiltering=True,
 #  addSoftDropSubjets=True,
 #  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-#  JETCorrPayload = 'AK8PF', JETCorrLevels = ['L2Relative', 'L3Absolute']
+#  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
 #)
-
-# AK R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
-  PUMethod='CHS',
-  addPruning=True, addSoftDrop=True ,           # add basic grooming
-  addTrimming=True, addFiltering=True,
-  addSoftDropSubjets=True,
-  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
-)
-
-# AK R=0.8 from PUPPI inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'noOutput',
-  PUMethod='Puppi',
-  addPruning=True, addSoftDrop=True ,           # add basic grooming
-  addTrimming=True, addFiltering=True,
-  addSoftDropSubjets=True,
-  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-  JETCorrPayload = 'AK8PFPuppi', JETCorrLevels = ['L2Relative', 'L3Absolute']
-)
-
-# CA R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ca8', 'ca8JetSubs', 'noOutput',
-  PUMethod='CHS',
-  addPruning=True, addSoftDrop=True ,           # add basic grooming
-  addTrimming=True, addFiltering=True,
-  addSoftDropSubjets=True,
-  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
-)
-
-# KT R=0.8 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'kt8', 'kt8JetSubs', 'noOutput',
-  PUMethod='CHS',
-  addPruning=True, addSoftDrop=True ,           # add basic grooming
-  addTrimming=True, addFiltering=True,
-  addSoftDropSubjets=True,
-  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
-)
-
-# AK R=1.2 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak12', 'ak12JetSubs', 'noOutput',
-  PUMethod='CHS',
-  addPruning=True, addSoftDrop=True ,           # add basic grooming
-  addTrimming=True, addFiltering=True,
-  addSoftDropSubjets=True,
-  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
-)
-
-# AK R=1.5 jets from CHS inputs with basic grooming, W tagging, and top tagging
-jetToolbox( process, 'ak15', 'ak15JetSubs', 'noOutput',
-  PUMethod='CHS',
-  addPruning=True, addSoftDrop=True ,           # add basic grooming
-  addTrimming=True, addFiltering=True,
-  addSoftDropSubjets=True,
-  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
-)
+#
+## AK R=1.5 jets from CHS inputs with basic grooming, W tagging, and top tagging
+#jetToolbox( process, 'ak15', 'ak15JetSubs', 'noOutput',
+#  PUMethod='CHS',
+#  addPruning=True, addSoftDrop=True ,           # add basic grooming
+#  addTrimming=True, addFiltering=True,
+#  addSoftDropSubjets=True,
+#  addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+#  JETCorrPayload = 'AK8PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute']
+#)
 
 ### MAKE SOME HISTOGRAMS
 process.ana = cms.EDAnalyzer('JetTester'
@@ -124,11 +227,8 @@ process.ana = cms.EDAnalyzer('JetTester'
 
 ### OUT
 process.TFileService = cms.Service("TFileService",
-      fileName = cms.string("JetClusterHistos_ZP3.root"),
+      fileName = cms.string("jetToolbox_longTest.root"),
       closeFileFast = cms.untracked.bool(True)
   )
-
-# Uncomment the following line if you would like to output the jet collections in a root file
-# process.endpath = cms.EndPath(process.out)
 
 process.p = cms.Path(process.ana)

--- a/test/ClusterWithToolboxAndMakeHistos.py
+++ b/test/ClusterWithToolboxAndMakeHistos.py
@@ -20,19 +20,17 @@ process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v1'
 process.GlobalTag.globaltag = '94X_mc2017_realistic_v12'
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 process.options.allowUnscheduled = cms.untracked.bool(True)
-process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 ### INPUT
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
-'/store/mc/RunIISummer17MiniAOD/ZprimeToTT_M-3000_W-300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/NZSFlatPU28to62_92X_upgrade2017_realistic_v10-v1/150000/E45A17E6-AAAC-E711-A423-00266CFFC80C.root'
-    )
+    fileNames = cms.untracked.vstring('/store/mc/RunIIAutumn18MiniAOD/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15_ext1-v2/20000/7E65457A-87E5-C146-8321-9A48B4F56ED1.root'),
 )
 
-from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
-process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
+#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
+#process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 
 btagDiscAK4 = [
             'pfCombinedInclusiveSecondaryVertexV2BJetTags',

--- a/test/jetToolbox_nanoAODv5_cfg.py
+++ b/test/jetToolbox_nanoAODv5_cfg.py
@@ -22,7 +22,7 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000)
+    input = cms.untracked.int32(-1)
 )
 
 # Input source
@@ -32,6 +32,7 @@ process.source = cms.Source("PoolSource",
 )
 #from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
 #process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 
 process.options = cms.untracked.PSet(

--- a/test/jetToolbox_nanoAODv5_cfg.py
+++ b/test/jetToolbox_nanoAODv5_cfg.py
@@ -1,0 +1,99 @@
+# Auto generated configuration file
+# using:
+# Revision: 1.19
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v
+# with command line options: myNanoProdMc2018_withJTB -s NANO --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --no_exec --conditions 102X_upgrade2018_realistic_v19 --era Run2_2018,run2_nanoAOD_102Xv1 --customise JMEAnalysis/JetToolbox/nanoAOD_jetToolbox_cff.nanoJTB_customizeMC --customise_commands=process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)))
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process('NANO',eras.Run2_2018,eras.run2_nanoAOD_102Xv1)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('PhysicsTools.NanoAOD.nano_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('/store/mc/RunIIAutumn18MiniAOD/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15_ext1-v2/20000/7E65457A-87E5-C146-8321-9A48B4F56ED1.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
+#process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
+
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('myNanoProdMc2018_withJTB nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.NANOAODSIMoutput = cms.OutputModule("NanoAODOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(9),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('NANOAODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('jetToolbox_nanoAODv5.root'),
+    outputCommands = process.NANOAODSIMEventContent.outputCommands
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '102X_upgrade2018_realistic_v19', '')
+
+# Path and EndPath definitions
+process.nanoAOD_step = cms.Path(process.nanoSequenceMC)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.NANOAODSIMoutput_step = cms.EndPath(process.NANOAODSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.nanoAOD_step,process.endjob_step,process.NANOAODSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from PhysicsTools.NanoAOD.nano_cff
+from PhysicsTools.NanoAOD.nano_cff import nanoAOD_customizeMC
+
+#call to customisation function nanoAOD_customizeMC imported from PhysicsTools.NanoAOD.nano_cff
+process = nanoAOD_customizeMC(process)
+
+# Automatic addition of the customisation function from JMEAnalysis.JetToolbox.nanoAOD_jetToolbox_cff
+from JMEAnalysis.JetToolbox.nanoAOD_jetToolbox_cff import nanoJTB_customizeMC
+
+#call to customisation function nanoJTB_customizeMC imported from JMEAnalysis.JetToolbox.nanoAOD_jetToolbox_cff
+process = nanoJTB_customizeMC(process)
+
+# End of customisation functions
+
+# Customisation from command line
+
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)))
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/test/jettoolbox_cfg.py
+++ b/test/jettoolbox_cfg.py
@@ -25,68 +25,8 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 
 from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
 
-'''
-jetToolbox( process, 'ak8', 'jetSequence', 'out', PUMethod='CHS', miniAOD=True,
-		#Cut='pt > 200 && abs(eta) < 2.5', # Tight
-		runOnMC=False,
-		addPruning = True, addSoftDrop = True,
-		addNsub    = True,
-		#addPrunedSubjets=True, addSoftDropSubjets=True,
-		#addNsubSubjets  =True
-		)
+jetToolbox( process, 'ak8', 'jetSequence', 'out', PUMethod='CHS', addPruning=False,  dataTier="AOD", runOnMC=False)   ### For example
 
-#jetToolbox( process, 'ak4', 'jetSequence', 'out', PUMethod='Puppi', miniAOD=True, runOnMC=True )
-#process.load('CommonTools.PileupAlgos.Puppi_cff')
-#process.PuppiOnTheFly = process.puppi.clone( candName = cms.InputTag( 'packedPFCandidates' ), vertexName = cms.InputTag( 'offlineSlimmedPrimaryVertices' ), clonePackedCands = cms.bool(True) )
-#process.PuppiOnTheFly.useExistingWeights = True
-#jetToolbox(process, 'ak4', 'dummy', 'out', PUMethod = 'Puppi', JETCorrPayload = 'AK4PFchs', JETCorrLevels = ['L2Relative', 'L3Absolute'], miniAOD = True, newPFCollection=True, nameNewPFCollection='puppi')
-
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='Puppi', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True , JETCorrPayload='AK8PFchs', subJETCorrPayload='AK4PFchs', subJETCorrLevels=['L2Relative', 'L3Absoulte'] ) #, Cut='pt > 100 && abs(eta) < 2.4' )
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='Puppi', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, JETCorrLevels=['L1FastJet', 'L2Relative'], newPFCollection=True, nameNewPFCollection='PuppiOnTheFly' )
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='SK', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, JETCorrLevels=['L1FastJet', 'L2Relative'] )
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True )
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addPrunedSubjets=True, addSoftDropSubjets=True, addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, addNsubSubjets=True )
-#jetToolbox( process, 'ak8', 'ak8JetSubs', 'out', PUMethod='CHS', addPruning=True, addSoftDrop=True , addSoftDropSubjets=True,  addNsub=True, maxTau=6, addTrimming=True, addFiltering=True, addNsubSubjets=True )
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
-		PUMethod='CHS',
-		#updateCollection='slimmedJetsAK8',
-		JETCorrPayload='AK8PFchs',
-		#addEnergyCorrFunc=True,
-		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets',
-		#subJETCorrPayload='AK4PFchs',
-		bTagDiscriminators=listBtagDiscriminatorsAK4,
-		#addNsubSubjets=True,
-		#addPrunedSubjets=True,
-		postFix= 'CollectionTests',
-		#addTrimming=True,
-		#addPruning=True
-		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' )
-listBtagDiscriminatorsAK4 = [
-                #'pfJetProbabilityBJetTags',
-                #'pfCombinedInclusiveSecondaryVertexV2BJetTags',
-                'pfCombinedMVAV2BJetTags',
-                #'pfCombinedCvsLJetTags',
-                #'pfCombinedCvsBJetTags',
-                ]
-jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
-		PUMethod='Puppi',
-		#updateCollection='slimmedJetsAK8',
-		JETCorrPayload='AK8PFPuppi',
-		#addEnergyCorrFunc=True,
-		#updateCollectionSubjets='slimmedJetsAK8PFCHSSoftDropPacked:SubJets',
-		subJETCorrPayload='AK4PFPuppi',
-		bTagDiscriminators=listBtagDiscriminatorsAK4,
-		addNsub    = True,
-		#addNsubSubjets=True,
-		#addPrunedSubjets=True,
-		#postFix= 'NEWCOLLECTIONOFJETS',
-		#addTrimming=True,
-		#addFiltering=True,
-		#addPruning=True,
-		addSoftDrop=True
-		)  #, addPrunedSubjets=True, subJETCorrPayload='AK4PFchs' )
-'''
-#from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
 #listBTagInfos = ['pfInclusiveSecondaryVertexFinderTagInfos','pfImpactParameterTagInfos']
 #listBtagDiscriminatorsAK8 = [
 # 'pfBoostedDoubleSecondaryVertexAK8BJetTags',
@@ -165,36 +105,61 @@ jetToolbox( process, 'ak8', 'ak8JetSubs', 'out',
 #                )
 #
 
-jetToolbox( process, 'ak15', 'ak15JetSubs', 'noOutput',
-   PUMethod='Puppi',
-   addPruning=True, addSoftDrop=True ,           # add basic grooming
-   addTrimming=True, addFiltering=True,
-   addSoftDropSubjets=True,
-   addPrunedSubjets=True,
-   addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
-   JETCorrPayload = 'AK8PFPuppi', #JETCorrLevels = ['L2Relative', 'L3Absolute'],
-   runOnMC=False,
-   miniAOD=True,
-   Cut='pt > 100 && abs(eta) < 2.5',
-   GetJetMCFlavour=False,
-   #GetSubJetMCFlavour=True,
-   addHEPTopTagger=True
-   )
+#jetToolbox( process, 'ak15', 'ak15JetSubs', 'noOutput',
+#   PUMethod='Puppi',
+#   addPruning=True, addSoftDrop=True ,           # add basic grooming
+#   addTrimming=True, addFiltering=True,
+#   addSoftDropSubjets=True,
+#   addPrunedSubjets=True,
+#   addNsub=True, maxTau=4,                       # add Nsubjettiness tau1, tau2, tau3, tau4
+#   JETCorrPayload = 'AK8PFPuppi', #JETCorrLevels = ['L2Relative', 'L3Absolute'],
+#   runOnMC=False,
+#   miniAOD=True,
+#   Cut='pt > 100 && abs(eta) < 2.5',
+#   GetJetMCFlavour=False,
+#   #GetSubJetMCFlavour=True,
+#   addHEPTopTagger=True
+#   )
+
+#bTagDiscriminators = [
+#    #'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+#    #'pfBoostedDoubleSecondaryVertexAK8BJetTags',
+#    'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
+#    'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
+#    #'pfDeepCSVJetTags:probb',
+#    #'pfDeepCSVJetTags:probbb',
+#]
+#subjetBTagDiscriminators = [
+#    'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+#    'pfDeepCSVJetTags:probb',
+#    'pfDeepCSVJetTags:probbb',
+#]
+#JETCorrLevels = ['L2Relative', 'L3Absolute', 'L2L3Residual']
+#
+#jetToolbox(process, 'ak8', 'dummyseq', 'out',
+#           dataTier='miniAOD',
+#           PUMethod='Puppi', JETCorrPayload='AK4PFPuppi', JETCorrLevels=JETCorrLevels,
+#           #addQGTagger=True,
+#           Cut='pt > 170.0 && abs(rapidity()) < 2.4',
+#           runOnMC=True,
+#           addNsub=True, maxTau=3, addEnergyCorrFunc=True,
+#           addSoftDrop=True, addSoftDropSubjets=True, subJETCorrPayload='AK4PFPuppi', subJETCorrLevels=JETCorrLevels,
+#           #bTagDiscriminators=bTagDiscriminators,
+#           #subjetBTagDiscriminators=subjetBTagDiscriminators
+#           )
 
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 process.source = cms.Source("PoolSource",
 #		fileNames = cms.untracked.vstring(#'file:example.root'
-		fileNames = cms.untracked.vstring(
-			'/store/data/Run2016G/JetHT/MINIAOD/PromptReco-v1/000/280/002/00000/E82E26C7-4375-E611-AE7F-FA163E48F736.root'
-			#'/store/mc/RunIIFall17MiniAOD/QCD_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/00000/02961665-F9F9-E711-87B5-0026B93F49B0.root'
-			#'/store/mc/RunIIFall17MiniAODv2/Res1ToRes2GluTo3Glu_M1-2000_R-0p1_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/00000/44F72487-F763-E811-9E6C-6C3BE5B5E4C0.root'
-			#'/store/relval/CMSSW_9_4_5_cand1/JetHT/MINIAOD/94X_dataRun2_relval_v11_RelVal_rmaod_jetHT2017B-v1/10000/18B5E95F-992E-E811-9422-0CC47A78A418.root'
+                fileNames = cms.untracked.vstring(
+                    #'/store/mc/RunIIAutumn18MiniAOD/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15_ext1-v2/20000/7E65457A-87E5-C146-8321-9A48B4F56ED1.root'
+                    '/store/data/Run2017C/DoubleMuon/AOD/17Nov2017-v1/50001/2005DA54-85D3-E711-BF10-02163E011E35.root'
 			),
 		)
 
-from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
-process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
+#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
+#process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 
 #from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
 #process.source.fileNames = filesRelValProdTTbarAODSIM


### PR DESCRIPTION
In this version it is included an additional option to run the jetToolbox as a customized option for nanoAOD. (aka it runs during the nanoAOD production, creating modified nanoAOD files) This part of the toolbox I call it in beta version since I have tested a couple of times without a problem but I would like the feedback from other users.
Also fixing some bugs for AOD and runOnMC.
