### PR TITLE
Fix the bug when calling QGTagger for updated jets

### DIFF
--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -450,7 +450,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		mod["PATJetsCorrFactors"] = 'patJetCorrFactors'+mod["PATJetsLabelPost"]
 		getattr( proc, mod["PATJetsCorrFactors"] ).payload = JETCorrPayload
 		getattr( proc, mod["PATJetsCorrFactors"] ).levels = JETCorrLevels
-		patJets = ('updatedPatJets' if bTagDiscriminators is None else 'updatedPatJetsTransientCorrected' )
+		patJets = 'updatedPatJets'
 		patSubJets = ''
 		selPatJets = 'selectedPatJets'
 		mod["PATJets"] = patJets+mod["PATJetsLabelPost"]


### PR DESCRIPTION
Fix the bug when choosing updateCollection with QGTagger. The error will be 
```
----- Begin Fatal Exception 10-Mar-2020 15:04:25 CET-----------------------
An exception of category 'InvalidReference' occurred while
   [0] Processing  Event run: 1 lumi: 2353 event: 2352007 stream: 0
   [1] Running path 'Path'
   [2] Prefetching for module ...
   [3] Prefetching for module PATJetSelector/'selectedPatJetsAK4PFCHS'
   [4] Calling method for module PATJetUpdater/'updatedPatJetsTransientCorrectedAK4PFCHS'
Exception Message:
ValueMap: no associated value for given product and index
----- End Fatal Exception -------------------------------------------------
```