### PR TITLE
option to reuse stored puppi weights

### DIFF
--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -29,7 +29,8 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 		updateCollection='', updateCollectionSubjets='',
 		newPFCollection=False, nameNewPFCollection = '',
 		PUMethod='CHS',
-                dataTier='miniAOD',
+		useExistingWeights=False, # for puppi
+		dataTier='miniAOD',
 		runOnMC=True,
 		JETCorrPayload='', JETCorrLevels = [ 'None' ], GetJetMCFlavour=True,
 		Cut = '',
@@ -258,6 +259,7 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 					if miniAOD:
 						puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
 						puppi.clonePackedCands = cms.bool(True)
+						puppi.useExistingWeights = useExistingWeights
 					_addProcessAndTask(proc, mod["puppi"], puppi)
 					jetSeq += getattr(proc, mod["puppi"])
 				srcForPFJets = mod["puppi"]


### PR DESCRIPTION
I had been under the impression that PUPPI weights weren't stored in the output miniAOD. However, they do appear to be stored in an ultra-legacy MC sample that I checked. Therefore, it can be useful to reuse the weights when clustering the existing packed PFCandidate collection, e.g. to get low-energy AK8 jets that aren't included in miniAOD by default or to get AK15 jets (this saves CPU vs. rerunning the entire PUPPI algorithm). The results vs. rerunning PUPPI are not identical, but the AK8 jet pT distributions are very similar (differences seem to be within the limit of numerical precision).