### PR TITLE
DeepDoubleX v2 can only run in updateJetCollection

### DIFF
--- a/python/jetToolbox_cff.py
+++ b/python/jetToolbox_cff.py
@@ -146,22 +146,22 @@ def jetToolbox( proc, jetType, jetSequence, outputFile,
 
 	defaultBoostedBTagDiscriminators = [
                         'pfBoostedDoubleSecondaryVertexAK8BJetTags',
-                        'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
-                        'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
-                        'pfMassIndependentDeepDoubleCvLJetTags:probQCD',
-                        'pfMassIndependentDeepDoubleCvLJetTags:probHcc',
-                        'pfMassIndependentDeepDoubleCvBJetTags:probHbb',
-                        'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
-                        ]
+	]
 
 	if updateCollection and (jetALGO=='AK8'):
 		defaultBoostedBTagDiscriminators += [
-			"pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight",
-			"pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ccvsLight",
-			"pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:TvsQCD",
-			"pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD",
-			"pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD",
-			"pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD"
+            "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:bbvsLight",
+            "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ccvsLight",
+            "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:TvsQCD",
+            "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHccvsQCD",
+            "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:WvsQCD",
+            "pfMassDecorrelatedDeepBoostedDiscriminatorsJetTags:ZHbbvsQCD",
+            'pfMassIndependentDeepDoubleBvLJetTags:probQCD',
+            'pfMassIndependentDeepDoubleBvLJetTags:probHbb',
+            'pfMassIndependentDeepDoubleCvLJetTags:probQCD',
+            'pfMassIndependentDeepDoubleCvLJetTags:probHcc',
+            'pfMassIndependentDeepDoubleCvBJetTags:probHbb',
+            'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
 		]
 
 	if bTagDiscriminators is '':


### PR DESCRIPTION
See #39184. This behavior starts in 10_6_X, so this change is overly conservative for 10_2_X, but I doubt we want to branch at this stage. In any case, this only changes the default behavior, so a user can override it if they really want.